### PR TITLE
Support more commands, support env-specific prefs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BIN := ./webhookdb
-ARGS := API_HOST=http://localhost:18001
+ARGS := WEBHOOKDB_API_HOST=http://localhost:18001
 
 guardcmd-%:
 	@hash $(*) > /dev/null 2>&1 || \
@@ -19,16 +19,16 @@ vet:
 
 test:
 	go test .
-	@LOG_LEVEL=fatal ginkgo -r --trace --race --progress --skipMeasurements
+	@WEBHOOKDB_LOG_LEVEL=fatal ginkgo -r --trace --race --progress --skipMeasurements
 
 test-watch:
-	@LOG_LEVEL=fatal ginkgo watch ./...
+	@WEBHOOKDB_LOG_LEVEL=fatal ginkgo watch ./...
 
 update-test-snapshots:
 	UPDATE_SNAPSHOTS=true make test
 
 bench:
-	@LOG_LEVEL=fatal ginkgo -r --focus=benchmarks
+	@WEBHOOKDB_LOG_LEVEL=fatal ginkgo -r --focus=benchmarks
 
 build:
 	@go build -ldflags \

--- a/client/backfill.go
+++ b/client/backfill.go
@@ -28,3 +28,26 @@ func Backfill(c context.Context, input BackfillInput) (step Step, err error) {
 	}
 	return step, nil
 }
+
+type BackfillResetInput struct {
+	AuthCookie types.AuthCookie `json:"-"`
+	OpaqueId   string           `json:"-"`
+}
+
+func BackfillReset(c context.Context, input BackfillResetInput) (step Step, err error) {
+	resty := RestyFromContext(c)
+	url := fmt.Sprintf("/v1/service_integrations/%v/backfill/reset", input.OpaqueId)
+	resp, err := resty.R().
+		SetBody(&input).
+		SetError(&ErrorResponse{}).
+		SetResult(&step).
+		SetHeader("Cookie", string(input.AuthCookie)).
+		Post(url)
+	if err != nil {
+		return step, err
+	}
+	if err := CoerceError(resp); err != nil {
+		return step, err
+	}
+	return step, nil
+}

--- a/client/db.go
+++ b/client/db.go
@@ -17,7 +17,7 @@ type DbTablesOutput struct {
 
 func DbTables(c context.Context, input DbTablesInput) (out DbTablesOutput, err error) {
 	resty := RestyFromContext(c)
-	url := fmt.Sprintf("/v1/db/%v", input.OrgIdentifier)
+	url := fmt.Sprintf("/v1/db/%v/tables", input.OrgIdentifier)
 	resp, err := resty.R().
 		SetError(&ErrorResponse{}).
 		SetResult(&out).

--- a/client/db.go
+++ b/client/db.go
@@ -6,6 +6,32 @@ import (
 	"github.com/lithictech/webhookdb-cli/types"
 )
 
+type DbConnectionInput struct {
+	AuthCookie    types.AuthCookie    `json:"-"`
+	OrgIdentifier types.OrgIdentifier `json:"-"`
+}
+
+type DbConnectionOutput struct {
+	ConnectionUrl string `json:"connection_url"`
+}
+
+func DbConnection(c context.Context, input DbConnectionInput) (out DbConnectionOutput, err error) {
+	resty := RestyFromContext(c)
+	url := fmt.Sprintf("/v1/db/%v/connection", input.OrgIdentifier)
+	resp, err := resty.R().
+		SetError(&ErrorResponse{}).
+		SetResult(&out).
+		SetHeader("Cookie", string(input.AuthCookie)).
+		Get(url)
+	if err != nil {
+		return out, err
+	}
+	if err := CoerceError(resp); err != nil {
+		return out, err
+	}
+	return out, nil
+}
+
 type DbTablesInput struct {
 	AuthCookie    types.AuthCookie    `json:"-"`
 	OrgIdentifier types.OrgIdentifier `json:"-"`
@@ -23,7 +49,6 @@ func DbTables(c context.Context, input DbTablesInput) (out DbTablesOutput, err e
 		SetResult(&out).
 		SetHeader("Cookie", string(input.AuthCookie)).
 		Get(url)
-	fmt.Println(resp)
 	if err != nil {
 		return out, err
 	}
@@ -54,7 +79,32 @@ func DbSql(c context.Context, input DbSqlInput) (out DbSqlOutput, err error) {
 		SetResult(&out).
 		SetHeader("Cookie", string(input.AuthCookie)).
 		Post(url)
-	fmt.Println(resp)
+	if err != nil {
+		return out, err
+	}
+	if err := CoerceError(resp); err != nil {
+		return out, err
+	}
+	return out, nil
+}
+
+type DbRollCredentialsInput struct {
+	AuthCookie    types.AuthCookie    `json:"-"`
+	OrgIdentifier types.OrgIdentifier `json:"-"`
+}
+
+type DbRollCredentialsOutput struct {
+	ConnectionUrl string `json:"connection_url"`
+}
+
+func DbRollCredentials(c context.Context, input DbRollCredentialsInput) (out DbRollCredentialsOutput, err error) {
+	resty := RestyFromContext(c)
+	url := fmt.Sprintf("/v1/db/%v/roll_credentials", input.OrgIdentifier)
+	resp, err := resty.R().
+		SetError(&ErrorResponse{}).
+		SetResult(&out).
+		SetHeader("Cookie", string(input.AuthCookie)).
+		Post(url)
 	if err != nil {
 		return out, err
 	}

--- a/client/entities.go
+++ b/client/entities.go
@@ -1,8 +1,11 @@
 package client
 
+import "github.com/lithictech/webhookdb-cli/types"
+
 type OrganizationMembershipEntity struct {
-	CustomerEmail string `json:"email"`
-	Status        string `json:"status"`
+	CustomerEmail string             `json:"email"`
+	Organization  types.Organization `json:"organization"`
+	Status        string             `json:"status"`
 }
 
 type ServiceEntity struct {

--- a/client/integrations.go
+++ b/client/integrations.go
@@ -55,3 +55,26 @@ func IntegrationsList(c context.Context, input IntegrationsListInput) (out Integ
 	}
 	return out, nil
 }
+
+type IntegrationsResetInput struct {
+	AuthCookie types.AuthCookie `json:"-"`
+	OpaqueId   string           `json:"-"`
+}
+
+func IntegrationsReset(c context.Context, input IntegrationsResetInput) (step Step, err error) {
+	resty := RestyFromContext(c)
+	url := fmt.Sprintf("/v1/service_integrations/%v/reset", input.OpaqueId)
+	resp, err := resty.R().
+		SetBody(&input).
+		SetError(&ErrorResponse{}).
+		SetResult(&step).
+		SetHeader("Cookie", string(input.AuthCookie)).
+		Post(url)
+	if err != nil {
+		return step, err
+	}
+	if err := CoerceError(resp); err != nil {
+		return step, err
+	}
+	return step, nil
+}

--- a/cmd/cmd_auth.go
+++ b/cmd/cmd_auth.go
@@ -1,13 +1,13 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"github.com/lithictech/webhookdb-cli/appcontext"
 	"github.com/lithictech/webhookdb-cli/client"
 	"github.com/lithictech/webhookdb-cli/prefs"
 	"github.com/urfave/cli/v2"
 )
-
-const PASSWORD_RETRY_ATTEMPTS = 3
 
 var authCmd = &cli.Command{
 	Name:        "auth",
@@ -17,8 +17,7 @@ var authCmd = &cli.Command{
 			Name:        "login",
 			Description: "logs a user in, sends them an otp",
 			Flags:       []cli.Flag{usernameFlag()},
-			Action: func(c *cli.Context) error {
-				ctx := newCtx(newAppCtx(c))
+			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
 				output, err := client.AuthLogin(ctx, client.AuthLoginInput{
 					Username: c.String("username"),
 				})
@@ -27,14 +26,13 @@ var authCmd = &cli.Command{
 				}
 				fmt.Println(output.Message)
 				return nil
-			},
+			}),
 		},
 		{
 			Name:        "otp",
 			Description: "registers the user's otp",
 			Flags:       []cli.Flag{usernameFlag(), tokenFlag()},
-			Action: func(c *cli.Context) error {
-				ctx := newCtx(newAppCtx(c))
+			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
 				output, err := client.AuthOTP(ctx, client.AuthOTPInput{
 					Username: c.String("username"),
 					Token:    c.String("token"),
@@ -42,32 +40,31 @@ var authCmd = &cli.Command{
 				if err != nil {
 					return err
 				}
-				p := prefs.Prefs{
-					AuthCookie: output.AuthCookie,
-					CurrentOrg: output.DefaultOrg,
-				}
-				if err := prefs.Save(p); err != nil {
+				p.AuthCookie = output.AuthCookie
+				p.CurrentOrg = output.DefaultOrg
+				ac.GlobalPrefs.SetNS(ac.Config.PrefsNamespace, p)
+				if err := prefs.Save(ac.GlobalPrefs); err != nil {
 					return err
 				}
 				fmt.Println(output.Message)
 				return nil
-			},
+			}),
 		},
 		{
 			Name:        "logout",
 			Description: "logs the current user out",
-			Action: func(c *cli.Context) error {
-				ctx := newCtx(newAppCtx(c))
+			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
 				output, err := client.AuthLogout(ctx)
 				if err != nil {
 					return err
 				}
-				if err := prefs.Delete(); err != nil {
+				ac.GlobalPrefs.ClearNS(ac.Config.PrefsNamespace)
+				if err := prefs.Save(ac.GlobalPrefs); err != nil {
 					return err
 				}
 				fmt.Println(output.Message)
 				return nil
-			},
+			}),
 		},
 	},
 }

--- a/cmd/cmd_backfill.go
+++ b/cmd/cmd_backfill.go
@@ -5,7 +5,6 @@ import (
 	"github.com/lithictech/webhookdb-cli/appcontext"
 	"github.com/lithictech/webhookdb-cli/client"
 	"github.com/lithictech/webhookdb-cli/prefs"
-	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 )
 
@@ -14,12 +13,13 @@ var backfillCmd = &cli.Command{
 	Description: "You can run this command to start a backfill of all the resources available to an integration.",
 	Flags:       []cli.Flag{},
 	Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
-		if c.NArg() != 1 {
-			return errors.New("Integration ID required. Use 'webhookdb integrations list'.")
+		opaqueId, err := extractIntegrationId(0, c)
+		if err != nil {
+			return err
 		}
 		input := client.BackfillInput{
 			AuthCookie: p.AuthCookie,
-			OpaqueId:   c.Args().Get(0),
+			OpaqueId:   opaqueId,
 		}
 		step, err := client.Backfill(ctx, input)
 		if err != nil {

--- a/cmd/cmd_backfill.go
+++ b/cmd/cmd_backfill.go
@@ -30,4 +30,29 @@ var backfillCmd = &cli.Command{
 		}
 		return nil
 	}),
+	Subcommands: []*cli.Command{
+		{
+			Name:        "reset",
+			Description: "Reset any stored API keys and secrets associated with backfilling this integration.",
+			Flags:       []cli.Flag{orgFlag()},
+			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
+				opaqueId, err := extractIntegrationId(0, c)
+				if err != nil {
+					return err
+				}
+				input := client.BackfillResetInput{
+					AuthCookie: p.AuthCookie,
+					OpaqueId:   opaqueId,
+				}
+				step, err := client.BackfillReset(ctx, input)
+				if err != nil {
+					return err
+				}
+				if err := client.NewStateMachine().Run(ctx, p, step); err != nil {
+					return err
+				}
+				return nil
+			}),
+		},
+	},
 }

--- a/cmd/cmd_db.go
+++ b/cmd/cmd_db.go
@@ -17,8 +17,21 @@ var dbCmd = &cli.Command{
 	Flags:       []cli.Flag{orgFlag()},
 	Subcommands: []*cli.Command{
 		{
+			Name:        "connection",
+			Description: "Print the database connection url for an organization.",
+			Flags:       []cli.Flag{orgFlag()},
+			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
+				out, err := client.DbConnection(ctx, client.DbConnectionInput{AuthCookie: p.AuthCookie, OrgIdentifier: getOrgFlag(c, p)})
+				if err != nil {
+					return err
+				}
+				fmt.Print(out.ConnectionUrl)
+				return nil
+			}),
+		},
+		{
 			Name:        "tables",
-			Description: "list all tables in organization's db",
+			Description: "List all tables in an organization's database.",
 			Flags:       []cli.Flag{orgFlag()},
 			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
 				out, err := client.DbTables(ctx, client.DbTablesInput{AuthCookie: p.AuthCookie, OrgIdentifier: getOrgFlag(c, p)})
@@ -31,7 +44,7 @@ var dbCmd = &cli.Command{
 		},
 		{
 			Name:        "sql",
-			Description: "execute query on organization's db",
+			Description: "Execute query on organization's database.",
 			Flags:       []cli.Flag{orgFlag()},
 			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
 				if c.NArg() != 1 {
@@ -46,6 +59,19 @@ var dbCmd = &cli.Command{
 				if out.MaxRowsReached {
 					fmt.Println("Results have been truncated.")
 				}
+				return nil
+			}),
+		},
+		{
+			Name:        "roll-credentials",
+			Description: "Roll the credentials for an organization's database to something newly randomly generated.",
+			Flags:       []cli.Flag{orgFlag()},
+			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
+				out, err := client.DbRollCredentials(ctx, client.DbRollCredentialsInput{AuthCookie: p.AuthCookie, OrgIdentifier: getOrgFlag(c, p)})
+				if err != nil {
+					return err
+				}
+				fmt.Print(out.ConnectionUrl)
 				return nil
 			}),
 		},

--- a/cmd/cmd_db.go
+++ b/cmd/cmd_db.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/lithictech/webhookdb-cli/appcontext"
 	"github.com/lithictech/webhookdb-cli/client"
@@ -47,10 +46,11 @@ var dbCmd = &cli.Command{
 			Description: "Execute query on organization's database.",
 			Flags:       []cli.Flag{orgFlag()},
 			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
-				if c.NArg() != 1 {
-					return errors.New("You must enter a query string.")
+				q, err := extractPositional(0, c, "You must enter a query string.")
+				if err != nil {
+					return err
 				}
-				out, err := client.DbSql(ctx, client.DbSqlInput{AuthCookie: p.AuthCookie, OrgIdentifier: getOrgFlag(c, p), Query: c.Args().Get(0)})
+				out, err := client.DbSql(ctx, client.DbSqlInput{AuthCookie: p.AuthCookie, OrgIdentifier: getOrgFlag(c, p), Query: q})
 				if err != nil {
 					return err
 				}

--- a/cmd/cmd_flags.go
+++ b/cmd/cmd_flags.go
@@ -59,3 +59,15 @@ func usernamesFlag() *cli.StringFlag {
 		Usage:    "Takes multiple emails.",
 	}
 }
+
+func extractPositional(idx int, c *cli.Context, msg string) (string, error) {
+	a := c.Args().Get(idx)
+	if a == "" {
+		return "", CliError{Message: msg, Code: 1}
+	}
+	return a, nil
+}
+
+func extractIntegrationId(idx int, c *cli.Context) (string, error) {
+	return extractPositional(idx, c, "Integration Id required. Use `webhookdb integrations list` to view all integrations.")
+}

--- a/cmd/cmd_helpers.go
+++ b/cmd/cmd_helpers.go
@@ -46,7 +46,8 @@ func cliAction(cb func(*cli.Context, appcontext.AppContext, context.Context, pre
 		if err != nil {
 			return err
 		}
-		if err := cb(c, ac, ctx, p); err != nil {
+		nsp := p.GetNS(ac.Config.PrefsNamespace)
+		if err := cb(c, ac, ctx, nsp); err != nil {
 			if eresp, ok := err.(client.ErrorResponse); ok {
 				return cli.Exit(eresp.Err.Message, 2)
 			}

--- a/cmd/cmd_helpers.go
+++ b/cmd/cmd_helpers.go
@@ -51,8 +51,20 @@ func cliAction(cb func(*cli.Context, appcontext.AppContext, context.Context, pre
 			if eresp, ok := err.(client.ErrorResponse); ok {
 				return cli.Exit(eresp.Err.Message, 2)
 			}
+			if ce, ok := err.(CliError); ok {
+				return cli.Exit(ce.Message, ce.Code)
+			}
 			return err
 		}
 		return nil
 	}
+}
+
+type CliError struct {
+	Message string
+	Code    int
+}
+
+func (e CliError) Error() string {
+	return e.Message
 }

--- a/cmd/cmd_integrations.go
+++ b/cmd/cmd_integrations.go
@@ -19,13 +19,14 @@ var integrationsCmd = &cli.Command{
 			Description: "create an integration for the given organization",
 			Flags:       []cli.Flag{orgFlag()},
 			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
-				if c.NArg() != 1 {
-					return errors.New("Service name required. Use 'webhookdb services list' to view all available services.")
+				serviceName, err := extractPositional(0, c, "Service name required. Use 'webhookdb services list' to view all available services.")
+				if err != nil {
+					return err
 				}
 				input := client.IntegrationsCreateInput{
 					AuthCookie:    p.AuthCookie,
 					OrgIdentifier: getOrgFlag(c, p),
-					ServiceName:   c.Args().Get(0),
+					ServiceName:   serviceName,
 				}
 				step, err := client.IntegrationsCreate(ctx, input)
 				if err != nil {

--- a/cmd/cmd_integrations.go
+++ b/cmd/cmd_integrations.go
@@ -63,5 +63,28 @@ var integrationsCmd = &cli.Command{
 				return nil
 			}),
 		},
+		{
+			Name:        "reset",
+			Description: "Reset the webhook secret for this integration.",
+			Flags:       []cli.Flag{orgFlag()},
+			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
+				opaqueId, err := extractIntegrationId(0, c)
+				if err != nil {
+					return err
+				}
+				input := client.IntegrationsResetInput{
+					AuthCookie: p.AuthCookie,
+					OpaqueId:   opaqueId,
+				}
+				step, err := client.IntegrationsReset(ctx, input)
+				if err != nil {
+					return err
+				}
+				if err := client.NewStateMachine().Run(ctx, p, step); err != nil {
+					return err
+				}
+				return nil
+			}),
+		},
 	},
 }

--- a/cmd/cmd_organizations.go
+++ b/cmd/cmd_organizations.go
@@ -33,7 +33,8 @@ var organizationsCmd = &cli.Command{
 				if err != nil {
 					return err
 				}
-				if err := prefs.Save(p.ChangeOrg(out.Org)); err != nil {
+				ac.GlobalPrefs.SetNS(ac.Config.PrefsNamespace, p.ChangeOrg(out.Org))
+				if err := prefs.Save(ac.GlobalPrefs); err != nil {
 					return err
 				}
 				fmt.Println(fmt.Sprintf("%s is now your active organization. ", out.Org.DisplayString()))

--- a/cmd/cmd_organizations.go
+++ b/cmd/cmd_organizations.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/lithictech/webhookdb-cli/appcontext"
 	"github.com/lithictech/webhookdb-cli/ask"
@@ -22,10 +21,10 @@ var organizationsCmd = &cli.Command{
 			Description: "change the default organization for any command you run",
 			Flags:       []cli.Flag{},
 			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
-				if c.NArg() != 1 {
-					return errors.New("You must enter an organization key.")
+				orgSlug, err := extractPositional(0, c, "You must enter an organization key.")
+				if err != nil {
+					return err
 				}
-				orgSlug := c.Args().Get(0)
 				out, err := client.OrgGet(ctx, client.OrgGetInput{
 					AuthCookie:    p.AuthCookie,
 					OrgIdentifier: types.OrgIdentifierFromSlug(orgSlug),
@@ -105,12 +104,13 @@ var organizationsCmd = &cli.Command{
 			Description: "join an organization using a join code",
 			Flags:       []cli.Flag{},
 			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
-				if c.NArg() != 1 {
-					return errors.New("You must enter an invitation code.")
+				invCode, err := extractPositional(0, c, "You must enter an invitation code.")
+				if err != nil {
+					return err
 				}
 				input := client.OrgJoinInput{
 					AuthCookie:     p.AuthCookie,
-					InvitationCode: c.Args().Get(0),
+					InvitationCode: invCode,
 				}
 				out, err := client.OrgJoin(ctx, input)
 				if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -11,21 +11,38 @@ var BuildTime = "btime"
 var BuildSha = "bsha"
 
 type Config struct {
-	ApiHost   string
+	// ApiHost is the URL of the service, like
+	// https://api.production.webhookdb.com, or http://localhost:1234.
+	ApiHost string
+	// Use a non-empty environment variable value to enable debug mode,
+	// which uses debug-level logging and may change other behaviors.
 	Debug     bool
 	LogFile   string
 	LogFormat string
 	LogLevel  string
+	// PrefsNamespace is used to namespace different environments
+	// in the .webhookdb prefs file.
+	// It defaults to API_HOST but you can set it to something else
+	// so multiple api hosts can use the same prefs,
+	// like if they are backed by the same DB.
+	PrefsNamespace string
 }
 
 func LoadConfig(filenames ...string) Config {
 	_ = godotenv.Overload(filenames...)
 	cfg := Config{
-		ApiHost:   os.Getenv("API_HOST"),
-		Debug:     os.Getenv("DEBUG") != "",
-		LogFile:   os.Getenv("LOG_FILE"),
-		LogFormat: os.Getenv("LOG_FORMAT"),
-		LogLevel:  MustEnvStr("LOG_LEVEL"),
+		ApiHost:        MustEnvStr("WEBHOOKDB_API_HOST"),
+		Debug:          os.Getenv("WEBHOOKDB_DEBUG") != "",
+		LogFile:        os.Getenv("WEBHOOKDB_LOG_FILE"),
+		LogFormat:      os.Getenv("WEBHOOKDB_LOG_FORMAT"),
+		LogLevel:       MustEnvStr("WEBHOOKDB_LOG_LEVEL"),
+		PrefsNamespace: os.Getenv("WEBHOOKDB_PREFS_NAMESPACE"),
+	}
+	if cfg.PrefsNamespace == "" {
+		cfg.PrefsNamespace = cfg.ApiHost
+	}
+	if cfg.Debug {
+		cfg.LogLevel = "debug"
 	}
 	return cfg
 }
@@ -45,6 +62,6 @@ func MustSetEnv(k string, v interface{}) {
 }
 
 func init() {
-	MustSetEnv("LOG_LEVEL", "warn")
-	MustSetEnv("API_HOST", "https://webhookdb-api-production.herokuapp.com/")
+	MustSetEnv("WEBHOOKDB_LOG_LEVEL", "error")
+	MustSetEnv("WEBHOOKDB_API_HOST", "https://api.production.webhookdb.com")
 }

--- a/itest.sh
+++ b/itest.sh
@@ -1,91 +1,92 @@
 #!/usr/bin/env bash
 
-alias whtest="API_HOST=http://localhost:18001 ./webhookdb"
+export WEBHOOKDB_API_HOST=http://localhost:18001
+export WEBHOOKDB_LOG_LEVEL=debug
+export EXE=./webhookdb
 
 make build
 
-
 echo "*** Hello and welcome to the webhookdb integration test."
 
-echo "\n*** testing auth logout..."
-whtest auth logout
+echo "*** testing auth logout..."
+${EXE} auth logout
 
 
-echo "\n*** Please enter a primary email to use for auth:"
+echo "*** Please enter a primary email to use for auth:"
 read primaryemail
-whtest auth login --username=$primaryemail
-echo "*** Great! Now check that primary email and enter the OTP here: "
+${EXE} auth login --username=$primaryemail
+echo "*** Great! Now check that primary email or DB (customer_reset_codes) and enter the OTP here: "
 read primaryotp
-whtest auth otp --username=$primaryemail --token=$primaryotp
-echo "\n*** testing services list..."
-whtest services list
+${EXE} auth otp --username=$primaryemail --token=$primaryotp
+echo "*** testing services list..."
+${EXE} services list
 
-echo "\n*** testing org create..."
-whtest org create
+echo "*** testing org create..."
+${EXE} org create
 echo "What is the key for the the new org? i.e. what is the slugified version of the org name you just typed in:"
 read orgkey
 
-echo "\n*** testing org list..."
-whtest org list
+echo "*** testing org list..."
+${EXE} org list
 
-echo "\n*** testing org remove and optional org flag..."
-whtest org invite --org=$orgkey --username=albertobalsam@aphex.co
-whtest org remove --org=$orgkey --username=albertobalsam@aphex.co
+echo "*** testing org remove and optional org flag..."
+${EXE} org invite --org=$orgkey --username=albertobalsam@aphex.co
+${EXE} org remove --org=$orgkey --username=albertobalsam@aphex.co
 
-echo "\n*** testing org activate..."
-whtest org activate $orgkey
+echo "*** testing org activate..."
+${EXE} org activate $orgkey
 
-echo "\n*** testing org current..."
-whtest org current
+echo "*** testing org current..."
+${EXE} org current
 
 
-echo "\n*** Please enter a secondary email to test org invite functionality:"
+echo "*** Please enter a secondary email to test org invite functionality:"
 read secondaryemail
 echo "*** testing org invite..."
-whtest org invite --username=$secondaryemail
+${EXE} org invite --username=$secondaryemail
 
-echo "\n*** testing org changerole..."
-whtest org invite --username=albertobalsam@aphex.co
-whtest org changerole --usernames=$secondaryemail,albertobalsam@aphex.co --role=admin
+echo "*** testing org changerole..."
+${EXE} org invite --username=albertobalsam@aphex.co
+${EXE} org changerole --usernames=$secondaryemail,albertobalsam@aphex.co --role=admin
 
-whtest auth logout
-whtest auth login --username=$secondaryemail
+${EXE} auth logout
+${EXE} auth login --username=$secondaryemail
 
-echo "\n*** Great! We're gonna log into the second account in order to test join functionality and finish the test"
+echo "*** Great! We're gonna log into the second account in order to test join functionality and finish the test"
 echo "*** Now check that secondary email and enter the OTP here: "
 read secondaryotp
-whtest auth otp --username=$secondaryemail --token=$secondaryotp
+${EXE} auth otp --username=$secondaryemail --token=$secondaryotp
 
 
-echo "\n*** testing org join..."
+echo "*** testing org join..."
 echo "*** In your secondary email inbox, you should have also received an email with a join code. Entwher that join code here:"
 read joincode
-whtest org join $joincode
+${EXE} org join $joincode
 
-echo "\n*** testing org members..."
-whtest org members
+echo "*** testing org members..."
+${EXE} org members
 
-echo "\n*** testing integrations create..."
-whtest integrations create fake_v1
+echo "*** testing integrations create..."
+${EXE} integrations create fake_v1
 echo "What is the opaque_id of the new integration?"
 read opaqueId
 
-echo "\n*** testing integrations list..."
-whtest integrations list
+echo "*** testing integrations list..."
+${EXE} integrations list
 echo "*** What is the table name listed above?"
 read tableName
 
-echo "\n*** testing backfill..."
-whtest backfill $opaqueId
+echo "*** testing backfill..."
+${EXE} backfill $opaqueId
 
-echo "\n*** testing db tables..."
-whtest db tables
+echo "*** testing db tables..."
+${EXE} db tables
 
-echo "\n*** testing db sql..."
-whtest db sql "SELECT * FROM $tableName"
+echo "*** testing db sql..."
+${EXE} db sql "SELECT * FROM $tableName"
 
-echo "\n*** testing subscription info..."
-whtest subscription info
+echo "*** testing subscription info..."
+${EXE} subscription info
 
-echo "\n*** testing subscription edit..."
-whtest subscription edit
+echo "*** testing subscription edit..."
+${EXE} subscription edit


### PR DESCRIPTION
Fixes https://github.com/lithictech/webhookdb-api/issues/93

---

Add backfill reset and integrations reset commands

---

Improve how we handle single positional arguments

---

Add `db connection` and `db roll-credentials` commands

---

Add `auth whoami` command, rework current customer entity

---

Cleanup of itest, still needs some more work

---

Rename `db tables` endpoint

---

Support namespace-specific prefs so we can switch envs