### PR TITLE
Unify client code, reduce boilerplate

### DIFF
--- a/appcontext/appcontext.go
+++ b/appcontext/appcontext.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/go-resty/resty/v2"
 	"github.com/lithictech/go-aperitif/logctx"
+	"github.com/lithictech/webhookdb-cli/client"
 	"github.com/lithictech/webhookdb-cli/config"
 	"github.com/lithictech/webhookdb-cli/prefs"
 	"github.com/sirupsen/logrus"
@@ -16,6 +17,7 @@ type AppContext struct {
 	Resty       *resty.Client
 	GlobalPrefs *prefs.GlobalPrefs
 	Prefs       prefs.Prefs
+	Auth        client.Auth
 	logger      *logrus.Entry
 	//ActiveOrg    string (should be derived from a prefs dir)
 }
@@ -30,6 +32,7 @@ func New(command string, cfg config.Config) (ac AppContext, err error) {
 		return
 	}
 	ac.Prefs = ac.GlobalPrefs.GetNS(cfg.PrefsNamespace)
+	ac.Auth = client.Auth{Cookie: ac.Prefs.AuthCookie}
 	ac.Resty = newResty(cfg, ac.Prefs)
 	if ac.logger, err = logctx.NewLogger(logctx.NewLoggerInput{
 		Level:     cfg.LogLevel,

--- a/client/auth.go
+++ b/client/auth.go
@@ -30,19 +30,9 @@ func (o AuthCurrentCustomerOutput) PrintTo(w io.Writer) {
 	}
 }
 
-func AuthGetMe(c context.Context) (out AuthCurrentCustomerOutput, err error) {
-	resty := RestyFromContext(c)
-	resp, err := resty.R().
-		SetError(&ErrorResponse{}).
-		SetResult(&out).
-		Get("/v1/me")
-	if err != nil {
-		return out, err
-	}
-	if err := CoerceError(resp); err != nil {
-		return out, err
-	}
-	return out, nil
+func AuthGetMe(c context.Context, auth Auth) (out AuthCurrentCustomerOutput, err error) {
+	err = makeRequest(c, GET, auth, nil, &out, "/v1/me")
+	return
 }
 
 type AuthLoginInput struct {
@@ -54,19 +44,8 @@ type AuthLoginOutput struct {
 }
 
 func AuthLogin(c context.Context, input AuthLoginInput) (out AuthLoginOutput, err error) {
-	resty := RestyFromContext(c)
-	resp, err := resty.R().
-		SetBody(&input).
-		SetError(&ErrorResponse{}).
-		SetResult(&out).
-		Post("/v1/auth")
-	if err != nil {
-		return out, err
-	}
-	if err := CoerceError(resp); err != nil {
-		return out, err
-	}
-	return out, nil
+	err = makeRequest(c, POST, Auth{}, input, &out, "/v1/auth")
+	return
 }
 
 type AuthOTPInput struct {
@@ -105,17 +84,7 @@ type AuthLogoutOutput struct {
 	Message string `json:"message"`
 }
 
-func AuthLogout(c context.Context) (out AuthLogoutOutput, err error) {
-	resty := RestyFromContext(c)
-	resp, err := resty.R().
-		SetError(&ErrorResponse{}).
-		SetResult(&out).
-		Post("/v1/auth/logout")
-	if err != nil {
-		return out, err
-	}
-	if err := CoerceError(resp); err != nil {
-		return out, err
-	}
-	return out, nil
+func AuthLogout(c context.Context, auth Auth) (out AuthLogoutOutput, err error) {
+	err = makeRequest(c, POST, auth, nil, &out, "/v1/auth/logout")
+	return
 }

--- a/client/backfill.go
+++ b/client/backfill.go
@@ -2,52 +2,22 @@ package client
 
 import (
 	"context"
-	"fmt"
-	"github.com/lithictech/webhookdb-cli/types"
 )
 
 type BackfillInput struct {
-	AuthCookie types.AuthCookie `json:"-"`
-	OpaqueId   string           `json:"-"`
+	OpaqueId string `json:"-"`
 }
 
-func Backfill(c context.Context, input BackfillInput) (step Step, err error) {
-	resty := RestyFromContext(c)
-	url := fmt.Sprintf("/v1/service_integrations/%v/backfill", input.OpaqueId)
-	resp, err := resty.R().
-		SetBody(&input).
-		SetError(&ErrorResponse{}).
-		SetResult(&step).
-		SetHeader("Cookie", string(input.AuthCookie)).
-		Post(url)
-	if err != nil {
-		return step, err
-	}
-	if err := CoerceError(resp); err != nil {
-		return step, err
-	}
-	return step, nil
+func Backfill(c context.Context, auth Auth, input BackfillInput) (step Step, err error) {
+	err = makeRequest(c, POST, auth, nil, &step, "/v1/service_integrations/%v/backfill", input.OpaqueId)
+	return
 }
 
 type BackfillResetInput struct {
-	AuthCookie types.AuthCookie `json:"-"`
-	OpaqueId   string           `json:"-"`
+	OpaqueId string `json:"-"`
 }
 
-func BackfillReset(c context.Context, input BackfillResetInput) (step Step, err error) {
-	resty := RestyFromContext(c)
-	url := fmt.Sprintf("/v1/service_integrations/%v/backfill/reset", input.OpaqueId)
-	resp, err := resty.R().
-		SetBody(&input).
-		SetError(&ErrorResponse{}).
-		SetResult(&step).
-		SetHeader("Cookie", string(input.AuthCookie)).
-		Post(url)
-	if err != nil {
-		return step, err
-	}
-	if err := CoerceError(resp); err != nil {
-		return step, err
-	}
-	return step, nil
+func BackfillReset(c context.Context, auth Auth, input BackfillResetInput) (step Step, err error) {
+	err = makeRequest(c, POST, auth, nil, &step, "/v1/service_integrations/%v/backfill/reset", input.OpaqueId)
+	return
 }

--- a/client/db.go
+++ b/client/db.go
@@ -2,12 +2,10 @@ package client
 
 import (
 	"context"
-	"fmt"
 	"github.com/lithictech/webhookdb-cli/types"
 )
 
 type DbConnectionInput struct {
-	AuthCookie    types.AuthCookie    `json:"-"`
 	OrgIdentifier types.OrgIdentifier `json:"-"`
 }
 
@@ -15,25 +13,12 @@ type DbConnectionOutput struct {
 	ConnectionUrl string `json:"connection_url"`
 }
 
-func DbConnection(c context.Context, input DbConnectionInput) (out DbConnectionOutput, err error) {
-	resty := RestyFromContext(c)
-	url := fmt.Sprintf("/v1/db/%v/connection", input.OrgIdentifier)
-	resp, err := resty.R().
-		SetError(&ErrorResponse{}).
-		SetResult(&out).
-		SetHeader("Cookie", string(input.AuthCookie)).
-		Get(url)
-	if err != nil {
-		return out, err
-	}
-	if err := CoerceError(resp); err != nil {
-		return out, err
-	}
-	return out, nil
+func DbConnection(c context.Context, auth Auth, input DbConnectionInput) (out DbConnectionOutput, err error) {
+	err = makeRequest(c, GET, auth, nil, &out, "/v1/db/%v/connection", input.OrgIdentifier)
+	return
 }
 
 type DbTablesInput struct {
-	AuthCookie    types.AuthCookie    `json:"-"`
 	OrgIdentifier types.OrgIdentifier `json:"-"`
 }
 
@@ -41,25 +26,12 @@ type DbTablesOutput struct {
 	TableNames []string `json:"tables"`
 }
 
-func DbTables(c context.Context, input DbTablesInput) (out DbTablesOutput, err error) {
-	resty := RestyFromContext(c)
-	url := fmt.Sprintf("/v1/db/%v/tables", input.OrgIdentifier)
-	resp, err := resty.R().
-		SetError(&ErrorResponse{}).
-		SetResult(&out).
-		SetHeader("Cookie", string(input.AuthCookie)).
-		Get(url)
-	if err != nil {
-		return out, err
-	}
-	if err := CoerceError(resp); err != nil {
-		return out, err
-	}
-	return out, nil
+func DbTables(c context.Context, auth Auth, input DbTablesInput) (out DbTablesOutput, err error) {
+	err = makeRequest(c, GET, auth, nil, &out, "/v1/db/%v/tables", input.OrgIdentifier)
+	return
 }
 
 type DbSqlInput struct {
-	AuthCookie    types.AuthCookie    `json:"-"`
 	OrgIdentifier types.OrgIdentifier `json:"-"`
 	Query         string              `json:"query"`
 }
@@ -70,26 +42,12 @@ type DbSqlOutput struct {
 	MaxRowsReached bool     `json:"max_rows_reached"`
 }
 
-func DbSql(c context.Context, input DbSqlInput) (out DbSqlOutput, err error) {
-	resty := RestyFromContext(c)
-	url := fmt.Sprintf("/v1/db/%v/sql", input.OrgIdentifier)
-	resp, err := resty.R().
-		SetBody(input).
-		SetError(&ErrorResponse{}).
-		SetResult(&out).
-		SetHeader("Cookie", string(input.AuthCookie)).
-		Post(url)
-	if err != nil {
-		return out, err
-	}
-	if err := CoerceError(resp); err != nil {
-		return out, err
-	}
-	return out, nil
+func DbSql(c context.Context, auth Auth, input DbSqlInput) (out DbSqlOutput, err error) {
+	err = makeRequest(c, POST, auth, input, &out, "/v1/db/%v/sql", input.OrgIdentifier)
+	return
 }
 
 type DbRollCredentialsInput struct {
-	AuthCookie    types.AuthCookie    `json:"-"`
 	OrgIdentifier types.OrgIdentifier `json:"-"`
 }
 
@@ -97,19 +55,7 @@ type DbRollCredentialsOutput struct {
 	ConnectionUrl string `json:"connection_url"`
 }
 
-func DbRollCredentials(c context.Context, input DbRollCredentialsInput) (out DbRollCredentialsOutput, err error) {
-	resty := RestyFromContext(c)
-	url := fmt.Sprintf("/v1/db/%v/roll_credentials", input.OrgIdentifier)
-	resp, err := resty.R().
-		SetError(&ErrorResponse{}).
-		SetResult(&out).
-		SetHeader("Cookie", string(input.AuthCookie)).
-		Post(url)
-	if err != nil {
-		return out, err
-	}
-	if err := CoerceError(resp); err != nil {
-		return out, err
-	}
-	return out, nil
+func DbRollCredentials(c context.Context, auth Auth, input DbRollCredentialsInput) (out DbRollCredentialsOutput, err error) {
+	err = makeRequest(c, POST, auth, nil, &out, "/v1/db/%v/roll_credentials", input.OrgIdentifier)
+	return
 }

--- a/client/integrations.go
+++ b/client/integrations.go
@@ -2,79 +2,37 @@ package client
 
 import (
 	"context"
-	"fmt"
 	"github.com/lithictech/webhookdb-cli/types"
 )
 
 type IntegrationsCreateInput struct {
-	AuthCookie    types.AuthCookie    `json:"-"`
 	OrgIdentifier types.OrgIdentifier `json:"-"`
 	ServiceName   string              `json:"service_name"`
 }
 
-func IntegrationsCreate(c context.Context, input IntegrationsCreateInput) (step Step, err error) {
-	resty := RestyFromContext(c)
-	url := fmt.Sprintf("/v1/organizations/%v/service_integrations/create", input.OrgIdentifier)
-	resp, err := resty.R().
-		SetBody(&input).
-		SetError(&ErrorResponse{}).
-		SetResult(&step).
-		SetHeader("Cookie", string(input.AuthCookie)).
-		Post(url)
-	if err != nil {
-		return step, err
-	}
-	if err := CoerceError(resp); err != nil {
-		return step, err
-	}
-	return step, nil
+func IntegrationsCreate(c context.Context, auth Auth, input IntegrationsCreateInput) (out Step, err error) {
+	err = makeRequest(c, POST, auth, input, &out, "/v1/organizations/%v/service_integrations/create", input.OrgIdentifier)
+	return
 }
 
 type IntegrationsListInput struct {
-	AuthCookie    types.AuthCookie
-	OrgIdentifier types.OrgIdentifier
+	OrgIdentifier types.OrgIdentifier `json:"-"`
 }
 
 type IntegrationsListOutput struct {
 	Data []ServiceIntegrationEntity `json:"items"`
 }
 
-func IntegrationsList(c context.Context, input IntegrationsListInput) (out IntegrationsListOutput, err error) {
-	resty := RestyFromContext(c)
-	url := fmt.Sprintf("/v1/organizations/%v/service_integrations", input.OrgIdentifier)
-	resp, err := resty.R().
-		SetError(&ErrorResponse{}).
-		SetResult(&out).
-		SetHeader("Cookie", string(input.AuthCookie)).
-		Get(url)
-	if err != nil {
-		return out, err
-	}
-	if err := CoerceError(resp); err != nil {
-		return out, err
-	}
-	return out, nil
+func IntegrationsList(c context.Context, auth Auth, input IntegrationsListInput) (out IntegrationsListOutput, err error) {
+	err = makeRequest(c, GET, auth, nil, &out, "/v1/organizations/%v/service_integrations", input.OrgIdentifier)
+	return
 }
 
 type IntegrationsResetInput struct {
-	AuthCookie types.AuthCookie `json:"-"`
-	OpaqueId   string           `json:"-"`
+	OpaqueId string `json:"-"`
 }
 
-func IntegrationsReset(c context.Context, input IntegrationsResetInput) (step Step, err error) {
-	resty := RestyFromContext(c)
-	url := fmt.Sprintf("/v1/service_integrations/%v/reset", input.OpaqueId)
-	resp, err := resty.R().
-		SetBody(&input).
-		SetError(&ErrorResponse{}).
-		SetResult(&step).
-		SetHeader("Cookie", string(input.AuthCookie)).
-		Post(url)
-	if err != nil {
-		return step, err
-	}
-	if err := CoerceError(resp); err != nil {
-		return step, err
-	}
-	return step, nil
+func IntegrationsReset(c context.Context, auth Auth, input IntegrationsResetInput) (out Step, err error) {
+	err = makeRequest(c, POST, auth, nil, &out, "/v1/service_integrations/%v/reset", input.OpaqueId)
+	return
 }

--- a/client/organizations.go
+++ b/client/organizations.go
@@ -2,40 +2,25 @@ package client
 
 import (
 	"context"
-	"fmt"
 	"github.com/lithictech/webhookdb-cli/types"
 )
 
 type OrgCreateInput struct {
-	AuthCookie types.AuthCookie `json:"-"`
-	OrgName    string           `json:"name"`
+	OrgName string `json:"name"`
 }
 
 type OrgCreateOutput struct {
 	Message string `json:"message"`
 }
 
-func OrgCreate(c context.Context, input OrgCreateInput) (out OrgCreateOutput, err error) {
-	resty := RestyFromContext(c)
-	resp, err := resty.R().
-		SetError(&ErrorResponse{}).
-		SetBody(&input).
-		SetResult(&out).
-		SetHeader("Cookie", string(input.AuthCookie)).
-		Post("/v1/organizations/create")
-	if err != nil {
-		return out, err
-	}
-	if err := CoerceError(resp); err != nil {
-		return out, err
-	}
-	return out, nil
+func OrgCreate(c context.Context, auth Auth, input OrgCreateInput) (out OrgCreateOutput, err error) {
+	err = makeRequest(c, POST, auth, input, &out, "/v1/organizations/create")
+	return
 }
 
 type OrgChangeRolesInput struct {
-	AuthCookie    types.AuthCookie    `json:"-"`
-	Emails        string              `json:"emails"`
 	OrgIdentifier types.OrgIdentifier `json:"-"`
+	Emails        string              `json:"emails"`
 	RoleName      string              `json:"role_name"`
 }
 
@@ -43,26 +28,12 @@ type OrgChangeRolesOutput struct {
 	Message string `json:"message"`
 }
 
-func OrgChangeRoles(c context.Context, input OrgChangeRolesInput) (out []OrgChangeRolesOutput, err error) {
-	resty := RestyFromContext(c)
-	url := fmt.Sprintf("/v1/organizations/%v/change_roles", input.OrgIdentifier)
-	resp, err := resty.R().
-		SetError(&ErrorResponse{}).
-		SetBody(&input).
-		SetResult(&out).
-		SetHeader("Cookie", string(input.AuthCookie)).
-		Post(url)
-	if err != nil {
-		return out, err
-	}
-	if err := CoerceError(resp); err != nil {
-		return out, err
-	}
-	return out, nil
+func OrgChangeRoles(c context.Context, auth Auth, input OrgChangeRolesInput) (out []OrgChangeRolesOutput, err error) {
+	err = makeRequest(c, POST, auth, input, &out, "/v1/organizations/%v/change_roles", input.OrgIdentifier)
+	return
 }
 
 type OrgGetInput struct {
-	AuthCookie    types.AuthCookie    `json:"-"`
 	OrgIdentifier types.OrgIdentifier `json:"-"`
 }
 
@@ -71,26 +42,12 @@ type OrgGetOutput struct {
 	Message string             `json:"message"`
 }
 
-func OrgGet(c context.Context, input OrgGetInput) (out OrgGetOutput, err error) {
-	resty := RestyFromContext(c)
-	url := fmt.Sprintf("/v1/organizations/%v", input.OrgIdentifier)
-	resp, err := resty.R().
-		SetError(&ErrorResponse{}).
-		SetBody(&input).
-		SetResult(&out).
-		SetHeader("Cookie", string(input.AuthCookie)).
-		Get(url)
-	if err != nil {
-		return out, err
-	}
-	if err := CoerceError(resp); err != nil {
-		return out, err
-	}
-	return out, nil
+func OrgGet(c context.Context, auth Auth, input OrgGetInput) (out OrgGetOutput, err error) {
+	err = makeRequest(c, GET, auth, nil, &out, "/v1/organizations/%v", input.OrgIdentifier)
+	return
 }
 
 type OrgInviteInput struct {
-	AuthCookie    types.AuthCookie    `json:"-"`
 	OrgIdentifier types.OrgIdentifier `json:"-"`
 	Email         string              `json:"email"`
 }
@@ -99,76 +56,37 @@ type OrgInviteOutput struct {
 	Message string `json:"message"`
 }
 
-func OrgInvite(c context.Context, input OrgInviteInput) (out OrgInviteOutput, err error) {
-	resty := RestyFromContext(c)
-	url := fmt.Sprintf("/v1/organizations/%v/invite", input.OrgIdentifier)
-	resp, err := resty.R().
-		SetError(&ErrorResponse{}).
-		SetBody(&input).
-		SetResult(&out).
-		SetHeader("Cookie", string(input.AuthCookie)).
-		Post(url)
-	if err != nil {
-		return out, err
-	}
-	if err := CoerceError(resp); err != nil {
-		return out, err
-	}
-	return out, nil
+func OrgInvite(c context.Context, auth Auth, input OrgInviteInput) (out OrgInviteOutput, err error) {
+	err = makeRequest(c, POST, auth, input, &out, "/v1/organizations/%v/invite", input.OrgIdentifier)
+	return
 }
 
 type OrgJoinInput struct {
-	AuthCookie     types.AuthCookie `json:"-"`
-	InvitationCode string           `json:"invitation_code"`
+	InvitationCode string `json:"invitation_code"`
 }
 
 type OrgJoinOutput struct {
 	Message string `json:"message"`
 }
 
-func OrgJoin(c context.Context, input OrgJoinInput) (out OrgJoinOutput, err error) {
-	resty := RestyFromContext(c)
-	resp, err := resty.R().
-		SetError(&ErrorResponse{}).
-		SetBody(&input).
-		SetResult(&out).
-		SetHeader("Cookie", string(input.AuthCookie)).
-		Post("/v1/organizations/join")
-	if err != nil {
-		return out, err
-	}
-	if err := CoerceError(resp); err != nil {
-		return out, err
-	}
-	return out, nil
+func OrgJoin(c context.Context, auth Auth, input OrgJoinInput) (out OrgJoinOutput, err error) {
+	err = makeRequest(c, POST, auth, input, &out, "/v1/organizations/join")
+	return
 }
 
 type OrgListInput struct {
-	AuthCookie types.AuthCookie `json:"-"`
 }
 
 type OrgListOutput struct {
 	Items []types.Organization `json:"items"`
 }
 
-func OrgList(c context.Context, input OrgListInput) (out OrgListOutput, err error) {
-	resty := RestyFromContext(c)
-	resp, err := resty.R().
-		SetError(&ErrorResponse{}).
-		SetResult(&out).
-		SetHeader("Cookie", string(input.AuthCookie)).
-		Get("/v1/organizations/")
-	if err != nil {
-		return out, err
-	}
-	if err := CoerceError(resp); err != nil {
-		return out, err
-	}
-	return out, nil
+func OrgList(c context.Context, auth Auth, input OrgListInput) (out OrgListOutput, err error) {
+	err = makeRequest(c, GET, auth, input, &out, "/v1/organizations/")
+	return
 }
 
 type OrgMembersInput struct {
-	AuthCookie    types.AuthCookie    `json:"-"`
 	OrgIdentifier types.OrgIdentifier `json:"-"`
 }
 
@@ -176,25 +94,12 @@ type OrgMembersOutput struct {
 	Data []OrganizationMembershipEntity `json:"items"`
 }
 
-func OrgMembers(c context.Context, input OrgMembersInput) (out OrgMembersOutput, err error) {
-	resty := RestyFromContext(c)
-	url := fmt.Sprintf("/v1/organizations/%v/members", input.OrgIdentifier)
-	resp, err := resty.R().
-		SetError(&ErrorResponse{}).
-		SetResult(&out).
-		SetHeader("Cookie", string(input.AuthCookie)).
-		Get(url)
-	if err != nil {
-		return out, err
-	}
-	if err := CoerceError(resp); err != nil {
-		return out, err
-	}
-	return out, nil
+func OrgMembers(c context.Context, auth Auth, input OrgMembersInput) (out OrgMembersOutput, err error) {
+	err = makeRequest(c, GET, auth, input, &out, "/v1/organizations/%v/members", input.OrgIdentifier)
+	return
 }
 
 type OrgRemoveInput struct {
-	AuthCookie    types.AuthCookie    `json:"-"`
 	OrgIdentifier types.OrgIdentifier `json:"-"`
 	Email         string              `json:"email"`
 }
@@ -203,20 +108,7 @@ type OrgRemoveOutput struct {
 	Message string `json:"message"`
 }
 
-func OrgRemove(c context.Context, input OrgRemoveInput) (out OrgRemoveOutput, err error) {
-	resty := RestyFromContext(c)
-	url := fmt.Sprintf("/v1/organizations/%v/remove", input.OrgIdentifier)
-	resp, err := resty.R().
-		SetError(&ErrorResponse{}).
-		SetBody(&input).
-		SetResult(&out).
-		SetHeader("Cookie", string(input.AuthCookie)).
-		Post(url)
-	if err != nil {
-		return out, err
-	}
-	if err := CoerceError(resp); err != nil {
-		return out, err
-	}
-	return out, nil
+func OrgRemove(c context.Context, auth Auth, input OrgRemoveInput) (out OrgRemoveOutput, err error) {
+	err = makeRequest(c, POST, auth, input, &out, "/v1/organizations/%v/remove", input.OrgIdentifier)
+	return
 }

--- a/client/services.go
+++ b/client/services.go
@@ -2,29 +2,15 @@ package client
 
 import (
 	"context"
-	"github.com/lithictech/webhookdb-cli/types"
 )
 
-type ServicesListInput struct {
-	AuthCookie types.AuthCookie `json:"-"`
-}
+type ServicesListInput struct{}
 
 type ServicesListOutput struct {
 	Data []ServiceEntity `json:"items"`
 }
 
-func ServicesList(c context.Context, input ServicesListInput) (out ServicesListOutput, err error) {
-	resty := RestyFromContext(c)
-	resp, err := resty.R().
-		SetError(&ErrorResponse{}).
-		SetResult(&out).
-		SetHeader("Cookie", string(input.AuthCookie)).
-		Get("/v1/services/")
-	if err != nil {
-		return out, err
-	}
-	if err := CoerceError(resp); err != nil {
-		return out, err
-	}
-	return out, nil
+func ServicesList(c context.Context, auth Auth, input ServicesListInput) (out ServicesListOutput, err error) {
+	err = makeRequest(c, GET, auth, input, &out, "/v1/services")
+	return
 }

--- a/client/statemachine.go
+++ b/client/statemachine.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/lithictech/webhookdb-cli/ask"
-	"github.com/lithictech/webhookdb-cli/prefs"
 )
 
 type Step struct {
@@ -34,7 +33,7 @@ type StateMachine struct {
 	Println   Println
 }
 
-func (sm StateMachine) Run(c context.Context, p prefs.Prefs, startingStep Step) error {
+func (sm StateMachine) Run(c context.Context, auth Auth, startingStep Step) error {
 	step := startingStep
 	for {
 		if step.Complete {
@@ -56,11 +55,10 @@ func (sm StateMachine) Run(c context.Context, p prefs.Prefs, startingStep Step) 
 			return err
 		}
 		transitionInput := TransitionStepInput{
-			AuthCookie: p.AuthCookie,
-			PostUrl:    step.PostToUrl,
-			Value:      value,
+			PostUrl: step.PostToUrl,
+			Value:   value,
 		}
-		newStep, err := TransitionStep(c, transitionInput)
+		newStep, err := TransitionStep(c, auth, transitionInput)
 		if err != nil {
 			return err
 		}

--- a/client/subscriptions.go
+++ b/client/subscriptions.go
@@ -10,8 +10,7 @@ import (
 )
 
 type SubscriptionInfoInput struct {
-	AuthCookie    types.AuthCookie    `json:"-"`
-	OrgIdentifier types.OrgIdentifier `json:"identifier"`
+	OrgIdentifier types.OrgIdentifier `json:"-"`
 }
 
 type SubscriptionInfoOutput struct {
@@ -35,26 +34,12 @@ func (info SubscriptionInfoOutput) PrintTo(w io.Writer) {
 	}
 }
 
-func SubscriptionInfo(c context.Context, input SubscriptionInfoInput) (SubscriptionInfoOutput, error) {
-	resty := RestyFromContext(c)
-	var out = SubscriptionInfoOutput{}
-	url := fmt.Sprintf("/v1/organizations/%v/subscriptions", input.OrgIdentifier)
-	resp, err := resty.R().
-		SetError(&ErrorResponse{}).
-		SetResult(&out).
-		SetHeader("Cookie", string(input.AuthCookie)).
-		Get(url)
-	if err != nil {
-		return out, err
-	}
-	if err := CoerceError(resp); err != nil {
-		return out, err
-	}
-	return out, nil
+func SubscriptionInfo(c context.Context, auth Auth, input SubscriptionInfoInput) (out SubscriptionInfoOutput, err error) {
+	err = makeRequest(c, GET, auth, nil, &out, "/v1/organizations/%v/subscriptions", input.OrgIdentifier)
+	return
 }
 
 type SubscriptionEditInput struct {
-	AuthCookie    types.AuthCookie    `json:"-"`
 	OrgIdentifier types.OrgIdentifier `json:"identifier"`
 }
 
@@ -62,19 +47,7 @@ type SubscriptionEditOutput struct {
 	SessionUrl string `json:"url"`
 }
 
-func SubscriptionEdit(c context.Context, input SubscriptionEditInput) (out SubscriptionEditOutput, err error) {
-	resty := RestyFromContext(c)
-	url := fmt.Sprintf("/v1/organizations/%v/subscriptions/open_portal", input.OrgIdentifier)
-	resp, err := resty.R().
-		SetError(&ErrorResponse{}).
-		SetResult(&out).
-		SetHeader("Cookie", string(input.AuthCookie)).
-		Post(url)
-	if err != nil {
-		return out, err
-	}
-	if err := CoerceError(resp); err != nil {
-		return out, err
-	}
-	return out, nil
+func SubscriptionEdit(c context.Context, auth Auth, input SubscriptionEditInput) (out SubscriptionEditOutput, err error) {
+	err = makeRequest(c, POST, auth, input, &out, "/v1/organizations/%v/subscriptions/open_portal", input.OrgIdentifier)
+	return
 }

--- a/client/transitions.go
+++ b/client/transitions.go
@@ -2,38 +2,14 @@ package client
 
 import (
 	"context"
-	"github.com/lithictech/webhookdb-cli/types"
 )
 
 type TransitionStepInput struct {
-	AuthCookie types.AuthCookie `json:"-"`
-	PostUrl    string           `json:"-"`
-	Value      string           `json:"value"`
+	PostUrl string `json:"-"`
+	Value   string `json:"value"`
 }
 
-func TransitionStep(c context.Context, input TransitionStepInput) (step Step, err error) {
-	resty := RestyFromContext(c)
-	resp, err := resty.R().
-		SetBody(&input).
-		SetError(&ErrorResponse{}).
-		SetResult(&step).
-		SetHeader("Cookie", string(input.AuthCookie)).
-		Post(input.PostUrl)
-	if err != nil {
-		return step, err
-	}
-	if err := CoerceError(resp); err != nil {
-		return step, err
-	}
-	return step, nil
+func TransitionStep(c context.Context, auth Auth, input TransitionStepInput) (step Step, err error) {
+	err = makeRequest(c, POST, auth, input, &step, input.PostUrl)
+	return
 }
-
-//func NewStateMachine() statemachine.StateMachine {
-//	return statemachine.New(func(c context.Context, input string) (statemachine.Step, error) {
-//		output, err := TransitionStep(c, TransitionStepInput{Input: input})
-//		if err != nil {
-//			return statemachine.Step{}, err
-//		}
-//		return output.Step, nil
-//	})
-//}

--- a/cmd/cmd_auth.go
+++ b/cmd/cmd_auth.go
@@ -17,8 +17,8 @@ var authCmd = &cli.Command{
 		{
 			Name:        "whoami",
 			Description: "Print information about the current user",
-			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
-				output, err := client.AuthGetMe(ctx)
+			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context) error {
+				output, err := client.AuthGetMe(ctx, ac.Auth)
 				if err != nil {
 					return err
 				}
@@ -30,7 +30,7 @@ var authCmd = &cli.Command{
 			Name:        "login",
 			Description: "Sign up or log in.",
 			Flags:       []cli.Flag{usernameFlag()},
-			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
+			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context) error {
 				output, err := client.AuthLogin(ctx, client.AuthLoginInput{
 					Username: c.String("username"),
 				})
@@ -45,7 +45,7 @@ var authCmd = &cli.Command{
 			Name:        "otp",
 			Description: "Finish sign up or login in using the given One Time Password.",
 			Flags:       []cli.Flag{usernameFlag(), tokenFlag()},
-			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
+			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context) error {
 				output, err := client.AuthOTP(ctx, client.AuthOTPInput{
 					Username: c.String("username"),
 					Token:    c.String("token"),
@@ -53,9 +53,9 @@ var authCmd = &cli.Command{
 				if err != nil {
 					return err
 				}
-				p.AuthCookie = output.AuthCookie
-				p.CurrentOrg = output.CurrentCustomer.DefaultOrganization
-				ac.GlobalPrefs.SetNS(ac.Config.PrefsNamespace, p)
+				ac.Prefs.AuthCookie = output.AuthCookie
+				ac.Prefs.CurrentOrg = output.CurrentCustomer.DefaultOrganization
+				ac.GlobalPrefs.SetNS(ac.Config.PrefsNamespace, ac.Prefs)
 				if err := prefs.Save(ac.GlobalPrefs); err != nil {
 					return err
 				}
@@ -66,8 +66,8 @@ var authCmd = &cli.Command{
 		{
 			Name:        "logout",
 			Description: "Log out of your current session.",
-			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
-				output, err := client.AuthLogout(ctx)
+			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context) error {
+				output, err := client.AuthLogout(ctx, ac.Auth)
 				if err != nil {
 					return err
 				}

--- a/cmd/cmd_backfill.go
+++ b/cmd/cmd_backfill.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"github.com/lithictech/webhookdb-cli/appcontext"
 	"github.com/lithictech/webhookdb-cli/client"
-	"github.com/lithictech/webhookdb-cli/prefs"
 	"github.com/urfave/cli/v2"
 )
 
@@ -12,20 +11,19 @@ var backfillCmd = &cli.Command{
 	Name:        "backfill",
 	Description: "You can run this command to start a backfill of all the resources available to an integration.",
 	Flags:       []cli.Flag{},
-	Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
+	Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context) error {
 		opaqueId, err := extractIntegrationId(0, c)
 		if err != nil {
 			return err
 		}
 		input := client.BackfillInput{
-			AuthCookie: p.AuthCookie,
-			OpaqueId:   opaqueId,
+			OpaqueId: opaqueId,
 		}
-		step, err := client.Backfill(ctx, input)
+		step, err := client.Backfill(ctx, ac.Auth, input)
 		if err != nil {
 			return err
 		}
-		if err := client.NewStateMachine().Run(ctx, p, step); err != nil {
+		if err := client.NewStateMachine().Run(ctx, ac.Auth, step); err != nil {
 			return err
 		}
 		return nil
@@ -35,20 +33,19 @@ var backfillCmd = &cli.Command{
 			Name:        "reset",
 			Description: "Reset any stored API keys and secrets associated with backfilling this integration.",
 			Flags:       []cli.Flag{orgFlag()},
-			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
+			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context) error {
 				opaqueId, err := extractIntegrationId(0, c)
 				if err != nil {
 					return err
 				}
 				input := client.BackfillResetInput{
-					AuthCookie: p.AuthCookie,
-					OpaqueId:   opaqueId,
+					OpaqueId: opaqueId,
 				}
-				step, err := client.BackfillReset(ctx, input)
+				step, err := client.BackfillReset(ctx, ac.Auth, input)
 				if err != nil {
 					return err
 				}
-				if err := client.NewStateMachine().Run(ctx, p, step); err != nil {
+				if err := client.NewStateMachine().Run(ctx, ac.Auth, step); err != nil {
 					return err
 				}
 				return nil

--- a/cmd/cmd_db.go
+++ b/cmd/cmd_db.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/lithictech/webhookdb-cli/appcontext"
 	"github.com/lithictech/webhookdb-cli/client"
-	"github.com/lithictech/webhookdb-cli/prefs"
 	"github.com/urfave/cli/v2"
 	"strings"
 )
@@ -19,8 +18,8 @@ var dbCmd = &cli.Command{
 			Name:        "connection",
 			Description: "Print the database connection url for an organization.",
 			Flags:       []cli.Flag{orgFlag()},
-			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
-				out, err := client.DbConnection(ctx, client.DbConnectionInput{AuthCookie: p.AuthCookie, OrgIdentifier: getOrgFlag(c, p)})
+			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context) error {
+				out, err := client.DbConnection(ctx, ac.Auth, client.DbConnectionInput{OrgIdentifier: getOrgFlag(c, ac.Prefs)})
 				if err != nil {
 					return err
 				}
@@ -32,8 +31,8 @@ var dbCmd = &cli.Command{
 			Name:        "tables",
 			Description: "List all tables in an organization's database.",
 			Flags:       []cli.Flag{orgFlag()},
-			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
-				out, err := client.DbTables(ctx, client.DbTablesInput{AuthCookie: p.AuthCookie, OrgIdentifier: getOrgFlag(c, p)})
+			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context) error {
+				out, err := client.DbTables(ctx, ac.Auth, client.DbTablesInput{OrgIdentifier: getOrgFlag(c, ac.Prefs)})
 				if err != nil {
 					return err
 				}
@@ -45,12 +44,12 @@ var dbCmd = &cli.Command{
 			Name:        "sql",
 			Description: "Execute query on organization's database.",
 			Flags:       []cli.Flag{orgFlag()},
-			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
+			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context) error {
 				q, err := extractPositional(0, c, "You must enter a query string.")
 				if err != nil {
 					return err
 				}
-				out, err := client.DbSql(ctx, client.DbSqlInput{AuthCookie: p.AuthCookie, OrgIdentifier: getOrgFlag(c, p), Query: q})
+				out, err := client.DbSql(ctx, ac.Auth, client.DbSqlInput{OrgIdentifier: getOrgFlag(c, ac.Prefs), Query: q})
 				if err != nil {
 					return err
 				}
@@ -66,8 +65,8 @@ var dbCmd = &cli.Command{
 			Name:        "roll-credentials",
 			Description: "Roll the credentials for an organization's database to something newly randomly generated.",
 			Flags:       []cli.Flag{orgFlag()},
-			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
-				out, err := client.DbRollCredentials(ctx, client.DbRollCredentialsInput{AuthCookie: p.AuthCookie, OrgIdentifier: getOrgFlag(c, p)})
+			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context) error {
+				out, err := client.DbRollCredentials(ctx, ac.Auth, client.DbRollCredentialsInput{OrgIdentifier: getOrgFlag(c, ac.Prefs)})
 				if err != nil {
 					return err
 				}

--- a/cmd/cmd_helpers.go
+++ b/cmd/cmd_helpers.go
@@ -7,7 +7,6 @@ import (
 	"github.com/lithictech/webhookdb-cli/appcontext"
 	"github.com/lithictech/webhookdb-cli/client"
 	"github.com/lithictech/webhookdb-cli/config"
-	"github.com/lithictech/webhookdb-cli/prefs"
 	"github.com/urfave/cli/v2"
 	"log"
 	"os"
@@ -38,16 +37,11 @@ func newCtx(appCtx appcontext.AppContext) context.Context {
 	return appcontext.InContext(c, appCtx)
 }
 
-func cliAction(cb func(*cli.Context, appcontext.AppContext, context.Context, prefs.Prefs) error) cli.ActionFunc {
+func cliAction(cb func(*cli.Context, appcontext.AppContext, context.Context) error) cli.ActionFunc {
 	return func(c *cli.Context) error {
 		ac := newAppCtx(c)
 		ctx := newCtx(ac)
-		p, err := prefs.Load()
-		if err != nil {
-			return err
-		}
-		nsp := p.GetNS(ac.Config.PrefsNamespace)
-		if err := cb(c, ac, ctx, nsp); err != nil {
+		if err := cb(c, ac, ctx); err != nil {
 			if eresp, ok := err.(client.ErrorResponse); ok {
 				return cli.Exit(eresp.Err.Message, 2)
 			}

--- a/cmd/cmd_integrations.go
+++ b/cmd/cmd_integrations.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/lithictech/webhookdb-cli/appcontext"
 	"github.com/lithictech/webhookdb-cli/client"
-	"github.com/lithictech/webhookdb-cli/prefs"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 )
@@ -18,21 +17,20 @@ var integrationsCmd = &cli.Command{
 			Name:        "create",
 			Description: "create an integration for the given organization",
 			Flags:       []cli.Flag{orgFlag()},
-			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
+			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context) error {
 				serviceName, err := extractPositional(0, c, "Service name required. Use 'webhookdb services list' to view all available services.")
 				if err != nil {
 					return err
 				}
 				input := client.IntegrationsCreateInput{
-					AuthCookie:    p.AuthCookie,
-					OrgIdentifier: getOrgFlag(c, p),
+					OrgIdentifier: getOrgFlag(c, ac.Prefs),
 					ServiceName:   serviceName,
 				}
-				step, err := client.IntegrationsCreate(ctx, input)
+				step, err := client.IntegrationsCreate(ctx, ac.Auth, input)
 				if err != nil {
 					return err
 				}
-				if err := client.NewStateMachine().Run(ctx, p, step); err != nil {
+				if err := client.NewStateMachine().Run(ctx, ac.Auth, step); err != nil {
 					return err
 				}
 				return nil
@@ -42,12 +40,11 @@ var integrationsCmd = &cli.Command{
 			Name:        "list",
 			Description: "list all integrations for the given organization",
 			Flags:       []cli.Flag{orgFlag()},
-			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
+			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context) error {
 				input := client.IntegrationsListInput{
-					AuthCookie:    p.AuthCookie,
-					OrgIdentifier: getOrgFlag(c, p),
+					OrgIdentifier: getOrgFlag(c, ac.Prefs),
 				}
-				out, err := client.IntegrationsList(ctx, input)
+				out, err := client.IntegrationsList(ctx, ac.Auth, input)
 				if err != nil {
 					return err
 				}
@@ -67,20 +64,19 @@ var integrationsCmd = &cli.Command{
 			Name:        "reset",
 			Description: "Reset the webhook secret for this integration.",
 			Flags:       []cli.Flag{orgFlag()},
-			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
+			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context) error {
 				opaqueId, err := extractIntegrationId(0, c)
 				if err != nil {
 					return err
 				}
 				input := client.IntegrationsResetInput{
-					AuthCookie: p.AuthCookie,
-					OpaqueId:   opaqueId,
+					OpaqueId: opaqueId,
 				}
-				step, err := client.IntegrationsReset(ctx, input)
+				step, err := client.IntegrationsReset(ctx, ac.Auth, input)
 				if err != nil {
 					return err
 				}
-				if err := client.NewStateMachine().Run(ctx, p, step); err != nil {
+				if err := client.NewStateMachine().Run(ctx, ac.Auth, step); err != nil {
 					return err
 				}
 				return nil

--- a/cmd/cmd_services.go
+++ b/cmd/cmd_services.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/lithictech/webhookdb-cli/appcontext"
 	"github.com/lithictech/webhookdb-cli/client"
-	"github.com/lithictech/webhookdb-cli/prefs"
 	"github.com/urfave/cli/v2"
 	"strings"
 )
@@ -18,8 +17,8 @@ var servicesCmd = &cli.Command{
 			Name:        "list",
 			Description: "list all available services",
 			Flags:       []cli.Flag{},
-			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
-				out, err := client.ServicesList(ctx, client.ServicesListInput{AuthCookie: p.AuthCookie})
+			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context) error {
+				out, err := client.ServicesList(ctx, ac.Auth, client.ServicesListInput{})
 				if err != nil {
 					return err
 				}

--- a/cmd/cmd_subscriptions.go
+++ b/cmd/cmd_subscriptions.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/lithictech/webhookdb-cli/appcontext"
 	"github.com/lithictech/webhookdb-cli/client"
-	"github.com/lithictech/webhookdb-cli/prefs"
 	"github.com/pkg/browser"
 	"github.com/urfave/cli/v2"
 	"os"
@@ -18,8 +17,8 @@ var subscriptionsCmd = &cli.Command{
 			Name:        "info",
 			Description: "get information about an organization's subscription",
 			Flags:       []cli.Flag{orgFlag()},
-			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
-				out, err := client.SubscriptionInfo(ctx, client.SubscriptionInfoInput{AuthCookie: p.AuthCookie, OrgIdentifier: getOrgFlag(c, p)})
+			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context) error {
+				out, err := client.SubscriptionInfo(ctx, ac.Auth, client.SubscriptionInfoInput{OrgIdentifier: getOrgFlag(c, ac.Prefs)})
 				if err != nil {
 					return err
 				}
@@ -31,8 +30,8 @@ var subscriptionsCmd = &cli.Command{
 			Name:        "edit",
 			Description: "open stripe portal to edit subscription",
 			Flags:       []cli.Flag{orgFlag()},
-			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context, p prefs.Prefs) error {
-				out, err := client.SubscriptionEdit(ctx, client.SubscriptionEditInput{AuthCookie: p.AuthCookie, OrgIdentifier: getOrgFlag(c, p)})
+			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context) error {
+				out, err := client.SubscriptionEdit(ctx, ac.Auth, client.SubscriptionEditInput{OrgIdentifier: getOrgFlag(c, ac.Prefs)})
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
- Add a makeRequest method that cleans up a ton of duplication
  between client code.
- Add an Auth type so auth is separate from input params