### PR TITLE
Unify formatting system

### DIFF
--- a/client/integrations.go
+++ b/client/integrations.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"github.com/lithictech/webhookdb-cli/formatting"
 	"github.com/lithictech/webhookdb-cli/types"
 )
 
@@ -40,14 +41,17 @@ func IntegrationsReset(c context.Context, auth Auth, input IntegrationsResetInpu
 type IntegrationsStatusInput struct {
 	OpaqueId      string              `json:"-"`
 	OrgIdentifier types.OrgIdentifier `json:"-"`
+	Format        formatting.Format   `json:"-"`
 }
 
 type IntegrationsStatusOutput struct {
-	Header []string   `json:"headers"`
-	Rows   [][]string `json:"rows"`
+	Parsed interface{}
 }
 
-func IntegrationsStatus(c context.Context, auth Auth, input IntegrationsStatusInput) (out IntegrationsStatusOutput, err error) {
-	err = makeRequest(c, GET, auth, nil, &out, "/v1/organizations/%v/service_integrations/%v/status", input.OrgIdentifier, input.OpaqueId)
-	return
+func IntegrationsStats(c context.Context, auth Auth, input IntegrationsStatusInput) (IntegrationsStatusOutput, error) {
+	out := IntegrationsStatusOutput{
+		Parsed: input.Format.ApiResponsePtr(),
+	}
+	err := makeRequest(c, GET, auth, nil, out.Parsed, "/v1/organizations/%v/service_integrations/%v/stats?fmt=%s", input.OrgIdentifier, input.OpaqueId, input.Format.ApiRequestValue)
+	return out, err
 }

--- a/cmd/cmd_flags.go
+++ b/cmd/cmd_flags.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/lithictech/webhookdb-cli/formatting"
 	"github.com/lithictech/webhookdb-cli/prefs"
 	"github.com/lithictech/webhookdb-cli/types"
 	"github.com/urfave/cli/v2"
+	"strings"
 )
 
 func orgFlag() *cli.StringFlag {
@@ -55,6 +57,25 @@ func usernameFlag() *cli.StringFlag {
 		Aliases: s1("u"),
 		Usage:   "Takes an email.",
 	}
+}
+
+func formatFlag(defaultFmt formatting.Format) cli.Flag {
+	return &cli.StringFlag{
+		Name:    "format",
+		Aliases: s1("f"),
+		Value:   defaultFmt.FlagValue,
+		Usage:   "Format of the output. One of: " + strings.Join(formatting.FormatFlagValues(), ", "),
+	}
+}
+func getFormatFlag(c *cli.Context) formatting.Format {
+	f, ok := formatting.LookupByFlag(c.String("format"))
+	if !ok {
+		panic(CliError{
+			Message: fmt.Sprintf("Invalid --format flag value: %s. Must be one of: %s", c.String("format"), strings.Join(formatting.FormatFlagValues(), ", ")),
+			Code:    1,
+		})
+	}
+	return f
 }
 
 func extractPositional(idx int, c *cli.Context, msg string) string {

--- a/cmd/cmd_helpers.go
+++ b/cmd/cmd_helpers.go
@@ -7,7 +7,6 @@ import (
 	"github.com/lithictech/webhookdb-cli/appcontext"
 	"github.com/lithictech/webhookdb-cli/client"
 	"github.com/lithictech/webhookdb-cli/config"
-	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli/v2"
 	"log"
 	"os"
@@ -77,14 +76,6 @@ type CliError struct {
 
 func (e CliError) Error() string {
 	return e.Message
-}
-
-func configTableWriter(table *tablewriter.Table) {
-	table.SetBorder(false)
-	table.SetRowSeparator("")
-	table.SetColumnSeparator("")
-	table.SetCenterSeparator("")
-	table.SetHeaderLine(false)
 }
 
 func stateMachineResponseRunner(ctx context.Context, auth client.Auth) func(client.Step, error) error {

--- a/formatting/formatting.go
+++ b/formatting/formatting.go
@@ -1,0 +1,121 @@
+package formatting
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"github.com/olekukonko/tablewriter"
+	"io"
+)
+
+type Format struct {
+	FlagValue          string
+	ApiRequestValue    string
+	ApiResponsePtr     func() interface{}
+	WriteApiResponseTo func(o interface{}, w io.Writer) error
+	WriteTabular       func(t TabularResponse, w io.Writer) error
+}
+
+var JSON = Format{
+	FlagValue:       "json",
+	ApiRequestValue: "object",
+	ApiResponsePtr: func() interface{} {
+		return &ObjectResponse{}
+	},
+	WriteApiResponseTo: func(o interface{}, w io.Writer) error {
+		return jsonWriteObj(o, w)
+	},
+	WriteTabular: func(t TabularResponse, w io.Writer) error {
+		m := make([]map[string]interface{}, len(t.Rows))
+		for rowIdx, row := range t.Rows {
+			rowObj := make(map[string]interface{}, len(t.Headers))
+			for headerIdx, header := range t.Headers {
+				rowObj[header] = row[headerIdx]
+			}
+			m[rowIdx] = rowObj
+		}
+		return jsonWriteObj(m, w)
+	},
+}
+
+func jsonWriteObj(o interface{}, w io.Writer) error {
+	return json.NewEncoder(w).Encode(o)
+}
+
+var CSV = Format{
+	FlagValue:       "csv",
+	ApiRequestValue: "table",
+	ApiResponsePtr: func() interface{} {
+		return &TabularResponse{}
+	},
+	WriteApiResponseTo: func(o interface{}, w io.Writer) error {
+		t := o.(*TabularResponse)
+		return csvWriteTabular(*t, w)
+	},
+	WriteTabular: csvWriteTabular,
+}
+
+func csvWriteTabular(t TabularResponse, w io.Writer) error {
+	cw := csv.NewWriter(w)
+	if err := cw.Write(t.Headers); err != nil {
+		return err
+	}
+	return cw.WriteAll(t.Rows)
+}
+
+var Table = Format{
+	FlagValue:       "table",
+	ApiRequestValue: "table",
+	ApiResponsePtr: func() interface{} {
+		return &TabularResponse{}
+	},
+	WriteApiResponseTo: func(o interface{}, w io.Writer) error {
+		t := o.(*TabularResponse)
+		return tableWriteTabular(*t, w)
+	},
+	WriteTabular: tableWriteTabular,
+}
+
+func tableWriteTabular(t TabularResponse, w io.Writer) error {
+	table := tablewriter.NewWriter(w)
+	table.SetHeader(t.Headers)
+	ConfigureTableWriter(table)
+	for _, row := range t.Rows {
+		table.Append(row)
+	}
+	table.Render()
+	return nil
+}
+
+type TabularResponse struct {
+	Headers []string   `json:"headers"`
+	Rows    [][]string `json:"rows"`
+}
+
+type ObjectResponse map[string]interface{}
+
+var Formats = []Format{JSON, CSV, Table}
+
+func LookupByFlag(v string) (Format, bool) {
+	for _, f := range Formats {
+		if f.FlagValue == v {
+			return f, true
+		}
+	}
+	return Format{}, false
+}
+
+func FormatFlagValues() []string {
+	values := make([]string, len(Formats))
+	for i, f := range Formats {
+		values[i] = f.FlagValue
+	}
+	return values
+}
+
+func ConfigureTableWriter(table *tablewriter.Table) {
+	table.SetBorder(false)
+	table.SetRowSeparator("")
+	table.SetColumnSeparator("")
+	table.SetCenterSeparator("")
+	table.SetHeaderLine(false)
+}


### PR DESCRIPTION
Add a new 'formatting' package that can render API responses
and tabular data as objects, csv, and tables.

Use 'stats' endpoint instead of 'status'.

Fixes https://github.com/lithictech/webhookdb-api/issues/179