### PR TITLE
Cleanup to prepare for WASM

### DIFF
--- a/client/auth.go
+++ b/client/auth.go
@@ -40,7 +40,7 @@ type AuthLoginInput struct {
 }
 
 type AuthLoginOutput struct {
-	AuthCookie types.AuthCookie
+	AuthToken  types.AuthToken
 	OutputStep Step
 }
 

--- a/client/common.go
+++ b/client/common.go
@@ -20,8 +20,10 @@ func RestyFromContext(c context.Context) *resty.Client {
 }
 
 type Auth struct {
-	Cookie types.AuthCookie `json:"-"`
+	Token types.AuthToken `json:"-"`
 }
+
+const AuthTokenHeader = "Whdb-Auth-Token"
 
 type ErrorResponse struct {
 	Err struct {
@@ -98,8 +100,8 @@ func makeRequestWithResponse(c context.Context, method string, auth Auth, body, 
 	if outPtr != nil {
 		req = req.SetResult(outPtr)
 	}
-	if auth.Cookie != "" {
-		req = req.SetHeader("Cookie", string(auth.Cookie))
+	if auth.Token != "" {
+		req = req.SetHeader(AuthTokenHeader, string(auth.Token))
 	}
 	resp, err := req.Execute(method, url)
 	if err != nil {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2,11 +2,9 @@ package cmd
 
 import (
 	"github.com/urfave/cli/v2"
-	"log"
-	"os"
 )
 
-func Execute() {
+func BuildApp() *cli.App {
 	app := &cli.App{
 		Usage: `CLI for the WebhookDB (https://webhookdb.com) application. WebhookDB allows you
 to query any API in real-time with SQL.
@@ -40,8 +38,5 @@ The CLI also gives you quick access to the WebhookDB documentation:
 			versionCmd,
 		},
 	}
-	err := app.Run(os.Args)
-	if err != nil {
-		log.Fatal(err)
-	}
+	return app
 }

--- a/cmd/cmd_db.go
+++ b/cmd/cmd_db.go
@@ -8,7 +8,6 @@ import (
 	"github.com/lithictech/webhookdb-cli/client"
 	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli/v2"
-	"os"
 	"strings"
 )
 
@@ -25,7 +24,7 @@ var dbCmd = &cli.Command{
 				if err != nil {
 					return err
 				}
-				fmt.Print(out.ConnectionUrl)
+				fmt.Fprint(c.App.Writer, out.ConnectionUrl)
 				return nil
 			}),
 		},
@@ -38,7 +37,7 @@ var dbCmd = &cli.Command{
 				if err != nil {
 					return err
 				}
-				fmt.Println(strings.Join(out.TableNames, "\n"))
+				fmt.Fprintln(c.App.Writer, strings.Join(out.TableNames, "\n"))
 				return nil
 			}),
 		},
@@ -58,7 +57,7 @@ var dbCmd = &cli.Command{
 				if err != nil {
 					return err
 				}
-				table := tablewriter.NewWriter(os.Stdout)
+				table := tablewriter.NewWriter(c.App.Writer)
 
 				table.SetHeader(out.Columns)
 				headerCols := make([]tablewriter.Colors, len(out.Columns))
@@ -97,7 +96,7 @@ var dbCmd = &cli.Command{
 				if err != nil {
 					return err
 				}
-				fmt.Print(out.ConnectionUrl)
+				fmt.Fprint(c.App.Writer, out.ConnectionUrl)
 				return nil
 			}),
 		},
@@ -132,9 +131,9 @@ var dbCmd = &cli.Command{
 					return err
 				}
 				if c.Bool("raw") {
-					fmt.Println(convext.MustMarshal(out))
+					fmt.Fprintln(c.App.Writer, convext.MustMarshal(out))
 				} else {
-					fmt.Println(out["message"])
+					fmt.Fprintln(c.App.Writer, out["message"])
 				}
 				return nil
 			}),

--- a/cmd/cmd_docs.go
+++ b/cmd/cmd_docs.go
@@ -42,12 +42,12 @@ var docsCmd = &cli.Command{
 				result := markdown.Render(md, 80, 0)
 				if pager := getPager(); pager != "" {
 					pa := strings.Split(pager, " ")
-					c := exec.Command(pa[0], pa[1:]...)
-					c.Stdin = strings.NewReader(string(result))
-					c.Stdout = os.Stdout
-					return c.Run()
+					cm := exec.Command(pa[0], pa[1:]...)
+					cm.Stdin = strings.NewReader(string(result))
+					cm.Stdout = c.App.Writer
+					return cm.Run()
 				}
-				fmt.Print(string(result))
+				fmt.Fprint(c.App.Writer, string(result))
 				return nil
 			}),
 		},

--- a/cmd/cmd_fixtures.go
+++ b/cmd/cmd_fixtures.go
@@ -20,7 +20,7 @@ var fixturesCmd = &cli.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Println(out.SchemaSql)
+		fmt.Fprintln(c.App.Writer, out.SchemaSql)
 		return nil
 	}),
 }

--- a/cmd/cmd_integrations.go
+++ b/cmd/cmd_integrations.go
@@ -7,7 +7,6 @@ import (
 	"github.com/lithictech/webhookdb-cli/client"
 	"github.com/lithictech/webhookdb-cli/formatting"
 	"github.com/urfave/cli/v2"
-	"os"
 )
 
 var integrationsCmd = &cli.Command{
@@ -45,8 +44,8 @@ var integrationsCmd = &cli.Command{
 					return err
 				}
 				if len(out.Data) == 0 {
-					fmt.Println("This organization doesn't have any integrations set up yet.")
-					fmt.Println("Use `webhookdb services list` and `webhookdb integrations create` to set one up.")
+					fmt.Fprintln(c.App.Writer, "This organization doesn't have any integrations set up yet.")
+					fmt.Fprintln(c.App.Writer, "Use `webhookdb services list` and `webhookdb integrations create` to set one up.")
 					return nil
 				}
 
@@ -59,7 +58,7 @@ var integrationsCmd = &cli.Command{
 					Headers: []string{"Service", "Table", "Id"},
 					Rows:    rows,
 				}
-				return fmt.WriteTabular(tabular, os.Stdout)
+				return fmt.WriteTabular(tabular, c.App.Writer)
 			}),
 		},
 		{
@@ -96,7 +95,7 @@ var integrationsCmd = &cli.Command{
 				if err != nil {
 					return err
 				}
-				return input.Format.WriteApiResponseTo(out.Parsed, os.Stdout)
+				return input.Format.WriteApiResponseTo(out.Parsed, c.App.Writer)
 			}),
 		},
 	},

--- a/cmd/cmd_organizations.go
+++ b/cmd/cmd_organizations.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/lithictech/webhookdb-cli/appcontext"
 	"github.com/lithictech/webhookdb-cli/client"
-	"github.com/lithictech/webhookdb-cli/prefs"
 	"github.com/lithictech/webhookdb-cli/types"
 	"github.com/urfave/cli/v2"
 	"strings"
@@ -26,10 +25,11 @@ var organizationsCmd = &cli.Command{
 				if err != nil {
 					return err
 				}
-				if err := prefs.SetNSAndSave(ac.GlobalPrefs, ac.Config.PrefsNamespace, ac.Prefs.ChangeOrg(out.Org)); err != nil {
+				ac.Prefs = ac.Prefs.ChangeOrg(out.Org)
+				if err := ac.SavePrefs(); err != nil {
 					return err
 				}
-				fmt.Println(fmt.Sprintf("%s is now your active organization. ", out.Org.DisplayString()))
+				fmt.Fprintln(c.App.Writer, fmt.Sprintf("%s is now your active organization. ", out.Org.DisplayString()))
 				return nil
 			}),
 		},
@@ -58,7 +58,7 @@ var organizationsCmd = &cli.Command{
 				if err != nil {
 					return err
 				}
-				fmt.Println(out.Message)
+				fmt.Fprintln(c.App.Writer, out.Message)
 				return nil
 			}),
 		},
@@ -76,9 +76,9 @@ var organizationsCmd = &cli.Command{
 				if err != nil {
 					return err
 				}
-				fmt.Println(out.Message)
+				fmt.Fprintln(c.App.Writer, out.Message)
 				ac.Prefs.CurrentOrg = out.Organization
-				if err := prefs.SetNSAndSave(ac.GlobalPrefs, ac.Config.PrefsNamespace, ac.Prefs); err != nil {
+				if err := ac.SavePrefs(); err != nil {
 					return err
 				}
 				return nil
@@ -97,7 +97,7 @@ var organizationsCmd = &cli.Command{
 				if err != nil {
 					return err
 				}
-				fmt.Println(out.Message)
+				fmt.Fprintln(c.App.Writer, out.Message)
 				return nil
 			}),
 		},
@@ -115,7 +115,7 @@ var organizationsCmd = &cli.Command{
 				if err != nil {
 					return err
 				}
-				fmt.Println(out.Message)
+				fmt.Fprintln(c.App.Writer, out.Message)
 				return nil
 			}),
 		},
@@ -137,7 +137,7 @@ var organizationsCmd = &cli.Command{
 					}
 					keySlugs[i] = line
 				}
-				fmt.Println(strings.Join(keySlugs, "\n"))
+				fmt.Fprintln(c.App.Writer, strings.Join(keySlugs, "\n"))
 				return nil
 			}),
 		},
@@ -146,7 +146,7 @@ var organizationsCmd = &cli.Command{
 			Description: "display the name and slug of the currently active org",
 			Flags:       []cli.Flag{},
 			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context) error {
-				fmt.Println(ac.Prefs.CurrentOrg.DisplayString())
+				fmt.Fprintln(c.App.Writer, ac.Prefs.CurrentOrg.DisplayString())
 				return nil
 			}),
 		},
@@ -168,7 +168,7 @@ var organizationsCmd = &cli.Command{
 						members[i] = value.CustomerEmail
 					}
 				}
-				fmt.Println(strings.Join(members, "\n"))
+				fmt.Fprintln(c.App.Writer, strings.Join(members, "\n"))
 				return nil
 			}),
 		},
@@ -185,7 +185,7 @@ var organizationsCmd = &cli.Command{
 				if err != nil {
 					return err
 				}
-				fmt.Println(out.Message)
+				fmt.Fprintln(c.App.Writer, out.Message)
 				return nil
 			}),
 		},

--- a/cmd/cmd_services.go
+++ b/cmd/cmd_services.go
@@ -29,7 +29,7 @@ var servicesCmd = &cli.Command{
 				for i, value := range out.Data {
 					names[i] = value.Name
 				}
-				fmt.Println(strings.Join(names, "\n"))
+				fmt.Fprintln(c.App.Writer, strings.Join(names, "\n"))
 				return nil
 			}),
 		},

--- a/cmd/cmd_subscriptions.go
+++ b/cmd/cmd_subscriptions.go
@@ -7,7 +7,6 @@ import (
 	"github.com/lithictech/webhookdb-cli/client"
 	"github.com/lithictech/webhookdb-cli/whbrowser"
 	"github.com/urfave/cli/v2"
-	"os"
 )
 
 var subscriptionsCmd = &cli.Command{
@@ -22,7 +21,7 @@ var subscriptionsCmd = &cli.Command{
 				if err != nil {
 					return err
 				}
-				out.PrintTo(os.Stdout)
+				out.PrintTo(c.App.Writer)
 				return nil
 			}),
 		},
@@ -38,8 +37,8 @@ var subscriptionsCmd = &cli.Command{
 				if err := whbrowser.OpenURL(out.SessionUrl); err != nil {
 					return err
 				}
-				fmt.Println("You have been redirected to the Stripe Billing Portal:")
-				fmt.Println(out.SessionUrl)
+				fmt.Fprintln(c.App.Writer, "You have been redirected to the Stripe Billing Portal:")
+				fmt.Fprintln(c.App.Writer, out.SessionUrl)
 				return nil
 			}),
 		},

--- a/cmd/cmd_unix.go
+++ b/cmd/cmd_unix.go
@@ -1,0 +1,16 @@
+//go:build !wasm
+// +build !wasm
+
+package cmd
+
+import (
+	"log"
+	"os"
+)
+
+func Execute() {
+	err := BuildApp().Run(os.Args)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cmd/cmd_update.go
+++ b/cmd/cmd_update.go
@@ -8,7 +8,6 @@ import (
 	"github.com/lithictech/webhookdb-cli/config"
 	"github.com/lithictech/webhookdb-cli/whselfupdate"
 	"github.com/urfave/cli/v2"
-	"log"
 	"os"
 )
 
@@ -30,7 +29,7 @@ var updateCmd = &cli.Command{
 		if !forceUpdate {
 			v := semver.MustParse(config.Version)
 			if !found || latest.Version().LTE(v) {
-				fmt.Println("Already up-to-date.")
+				fmt.Fprintln(c.App.Writer, "Already up-to-date.")
 				return nil
 			}
 		}
@@ -42,11 +41,11 @@ var updateCmd = &cli.Command{
 			}
 			path = exe
 		}
-		fmt.Printf("Updating from %s to %s\n", config.Version, latest.Version().String())
+		fmt.Fprintf(c.App.Writer, "Updating from %s to %s\n", config.Version, latest.Version().String())
 		if err := whselfupdate.UpdateTo(latest.AssetURL(), path); err != nil {
 			return CliError{Message: fmt.Sprintf("Error occurred while updating binary: %s", err)}
 		}
-		log.Printf("Successfully updated to %s\n", latest.Version().String())
+		fmt.Fprintf(c.App.Writer, "Successfully updated to %s\n", latest.Version().String())
 		return nil
 	}),
 }

--- a/cmd/cmd_version.go
+++ b/cmd/cmd_version.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/lithictech/webhookdb-cli/config"
 	"github.com/urfave/cli/v2"
-	"os"
 )
 
 var versionCmd = &cli.Command{
@@ -14,7 +13,7 @@ var versionCmd = &cli.Command{
 		if len(shaPart) >= 8 {
 			shaPart = fmt.Sprintf(" (%s)", config.BuildSha[0:8])
 		}
-		fmt.Fprintf(os.Stdout, "%s%s\n", config.Version, shaPart)
+		fmt.Fprintf(c.App.Writer, "%s%s\n", config.Version, shaPart)
 		return nil
 	},
 }

--- a/cmd/cmd_wasm.go
+++ b/cmd/cmd_wasm.go
@@ -1,0 +1,8 @@
+//go:build wasm
+// +build wasm
+
+package cmd
+
+func Execute() {
+	panic("implement me")
+}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/go-resty/resty/v2 v2.6.0
 	github.com/google/uuid v1.1.2 // indirect
-	github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00
 	github.com/joho/godotenv v1.3.0
 	github.com/lithictech/go-aperitif v0.0.0-20201008180713-efd6b162b762
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
@@ -18,6 +17,7 @@ require (
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pkg/browser v0.0.0-20210706143420-7d21f8c997e2
+	github.com/pkg/errors v0.9.1
 	github.com/rhysd/go-github-selfupdate v1.2.3
 	github.com/sirupsen/logrus v1.8.1
 	github.com/urfave/cli/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -68,7 +68,6 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
-github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00 h1:l5lAOZEym3oK3SQ2HBHWsJUfbNBiTXJDeW2QDxw9AQ0=
 github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -131,6 +130,7 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/pkg/browser v0.0.0-20210706143420-7d21f8c997e2 h1:acNfDZXmm28D2Yg/c3ALnZStzNaZMSagpbr96vY6Zjc=
 github.com/pkg/browser v0.0.0-20210706143420-7d21f8c997e2/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/types/types.go
+++ b/types/types.go
@@ -15,7 +15,7 @@ func OrgIdentifierFromSlug(slug string) OrgIdentifier {
 	return OrgIdentifier(slug)
 }
 
-type AuthCookie string
+type AuthToken string
 
 type Organization struct {
 	// The primary key of the organization.

--- a/whbrowser/whbrowser_wasm.go
+++ b/whbrowser/whbrowser_wasm.go
@@ -4,10 +4,10 @@
 package whbrowser
 
 import (
-	"github.com/gopherjs/gopherjs/js"
+	"syscall/js"
 )
 
 func OpenURL(url string) error {
-	js.Global.Get("window").Call("open", url)
+	js.Global().Get("window").Call("open", url)
 	return nil
 }

--- a/whfs/whfs.go
+++ b/whfs/whfs.go
@@ -1,0 +1,12 @@
+package whfs
+
+import (
+	"io"
+)
+
+type FS interface {
+	Open(path string) (io.ReadCloser, error)
+	CreateWithDirs(path string) (io.WriteCloser, error)
+	Remove(root string) error
+	UserHomeDir() (string, error)
+}

--- a/whfs/whfs_unix.go
+++ b/whfs/whfs_unix.go
@@ -1,0 +1,39 @@
+//go:build !wasm
+// +build !wasm
+
+package whfs
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+)
+
+func New() FS {
+	return osfs{}
+}
+
+type osfs struct{}
+
+func (o osfs) Remove(root string) error {
+	return os.Remove(root)
+}
+
+func (o osfs) UserHomeDir() (string, error) {
+	return os.UserHomeDir()
+}
+
+func (o osfs) Open(path string) (io.ReadCloser, error) {
+	return os.Open(path)
+}
+
+func (o osfs) CreateWithDirs(path string) (io.WriteCloser, error) {
+	if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
+		return nil, err
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}

--- a/whfs/whfs_wasm.go
+++ b/whfs/whfs_wasm.go
@@ -1,0 +1,30 @@
+//go:build wasm
+// +build wasm
+
+package whfs
+
+import (
+	"io"
+)
+
+func New() FS {
+	return jsfs{}
+}
+
+type jsfs struct{}
+
+func (o jsfs) Remove(root string) error {
+	panic("implement me")
+}
+
+func (o jsfs) UserHomeDir() (string, error) {
+	panic("implement me")
+}
+
+func (o jsfs) Open(path string) (io.ReadCloser, error) {
+	panic("implement me")
+}
+
+func (o jsfs) CreateWithDirs(path string) (io.WriteCloser, error) {
+	panic("implement me")
+}


### PR DESCRIPTION
- Pull filesystem access into whfs
- Remove all os.Stderr/Stdout usage in cmds,
  instead use `fmt.Fprintln(c.App.Writer)` and similar.
- Nicer 401 output
- Use new auth token header as per
  https://github.com/lithictech/webhookdb-api/pull/197