### PR TITLE
Support interactive prompt, fix recursive state machines

### DIFF
--- a/ask/ask_wasm.go
+++ b/ask/ask_wasm.go
@@ -13,19 +13,42 @@ func New() Ask {
 	return &a
 }
 
+var feedbackNotSetWarned = false
+var promptNotSetWarned = false
+
 type jsask struct{}
 
 func (j jsask) Ask(prompt string) (string, error) {
-	result := js.Global().Call("prompt", prompt)
-	return result.String(), nil
+	return j.ask(prompt, false)
 }
 
 func (j jsask) HiddenAsk(prompt string) (string, error) {
-	result := js.Global().Call("prompt", prompt)
-	return result.String(), nil
+	return j.ask(prompt, true)
 }
 
-var feedbackNotSetWarned = false
+func (j jsask) ask(prompt string, hidden bool) (string, error) {
+	wasmPrompt := js.Global().Get("wasmPropt")
+	if !wasmPrompt.Truthy() {
+		if promptNotSetWarned {
+			promptNotSetWarned = true
+			fmt.Println("wasmPrompt global function is not set, falling back to prompt builtin")
+		}
+		result := js.Global().Call("prompt", prompt)
+		if !result.Truthy() {
+			return "", nil
+		}
+		return result.String(), nil
+	}
+	ch := make(chan string)
+	cb := func(this js.Value, args []js.Value) interface{} {
+		ch <- args[0].String()
+		return nil
+	}
+	go func() {
+		wasmPrompt.Invoke(prompt, hidden, js.FuncOf(cb))
+	}()
+	return <-ch, nil
+}
 
 func (j jsask) Feedback(line string) {
 	fb := js.Global().Get("wasmFeedback")


### PR DESCRIPTION
Fix issue with recursive state machines during error handling
printing duplicate output as they unwind.

Support 'wasmPrompt' js global for interactive prompts
that don't use JS prompts.
JS prompts are brittle (they go away on tab switch).