### PR TITLE
Fix auth and color issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ build-wasm:
 
 build-all: build-arm64 build build-wasm
 
+copy-wasm-to-web:
+	cp webhookdb.wasm ../webhookdb-api/webhookdb-website/static/webterm
+
 docs-write: build
 	@$(BIN) docs build > MANUAL.md
 

--- a/cmd/cmd_unix.go
+++ b/cmd/cmd_unix.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"github.com/getsentry/sentry-go"
+	"github.com/lithictech/go-aperitif/logctx"
 	"github.com/lithictech/webhookdb-cli/config"
 	"github.com/lithictech/webhookdb-cli/prefs"
 	"log"
@@ -52,3 +53,5 @@ func configureSentry() bool {
 }
 
 func wasmUpdateAuthDisplay(_ prefs.Prefs) {}
+
+var IsTty = logctx.IsTty()

--- a/cmd/cmd_wasm.go
+++ b/cmd/cmd_wasm.go
@@ -105,3 +105,5 @@ func wasmUpdateAuthDisplay(p prefs.Prefs) {
 	}
 	cb.Invoke(string(j))
 }
+
+var IsTty = false


### PR DESCRIPTION
Table writer only uses colors in a real tty

Fixes https://github.com/lithictech/webhookdb-api/issues/215

---

Fix bug during auth

We were using the wrong variable reference
(the one before auth), so didn't have the right values.

Was causing all sorts of weird auth bugs.

Fixes https://github.com/lithictech/webhookdb-api/issues/213

---

Make command to copy wasm to web