### PR TITLE
Add helper to copy and modify manual to website

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -95,6 +95,8 @@ List all tables in an organization's database.
 
 Execute query on organization's database.
 
+**--color, -c**: Display colors. Default true if tty.
+
 **--org, -o**="": Takes an org key. Run `webhook org list` to see a list of all your org keys.
 
 **--query, -u**="": Query string to execute using your connection.
@@ -115,13 +117,13 @@ Write out commands that can be used to generate a FDW against your WebhookDB dat
 
 **--fetch**="": fetch_size option used during server creation (default: 50000)
 
-**--into-schema**="": Name of the schema to import the remote tables into (IMPORT FOREIGN SCHEMA public INTO <into schema>. (default: webhookdb_remote)
+**--into-schema**="": Name of the schema to import the remote tables into (in `IMPORT FOREIGN SCHEMA public INTO <into schema>` call). (default: webhookdb_remote)
 
 **--org, -o**="": Takes an org key. Run `webhook org list` to see a list of all your org keys.
 
 **--raw**: If given, print the raw SQL returned from the server. Useful if you want to pipe through jq or something similar.
 
-**--remote**="": The remote server name, used in the 'CREATE SERVER <remote>' call (default: webhookdb_remote)
+**--remote**="": The remote server name, used in the `CREATE SERVER <remote>` call (default: webhookdb_remote)
 
 **--views**: Write the SQL to create the materialized views to stdout
 
@@ -166,6 +168,16 @@ Create an integration for the given organization.
 **--org, -o**="": Takes an org key. Run `webhook org list` to see a list of all your org keys.
 
 **--service, -s**="": Name of the service. Run `webhookdb services list` to see a list of all services available to your organization.
+
+### delete
+
+Delete an integration and its table.
+
+**--confirm, -c**="": Confirm this action by providing a value of the integration's table name. Will be prompted if not provided.
+
+**--integration, -i**="": Integration opaque id, starting with 'svi_'. Run `webhookdb integrations list` to see a list of all your integrations.
+
+**--org, -o**="": Takes an org key. Run `webhook org list` to see a list of all your org keys.
 
 ### list
 
@@ -253,6 +265,14 @@ Remove a member from an organization.
 
 **--username, -u**="": Takes an email.
 
+### rename
+
+Change the name of the organization. Does not change the org key, which is immutable.
+
+**--name, -n**="": New name of the organization
+
+**--org, -o**="": Takes an org key. Run `webhook org list` to see a list of all your org keys.
+
 ## services
 
 Work with available services that can be hooked up to reflect data to WebhookDB.
@@ -320,4 +340,3 @@ Print version and exit.
 ## help, h
 
 Shows a list of commands or help for one command
-%!(EXTRA <nil>)

--- a/bin/copy-manual/main.go
+++ b/bin/copy-manual/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+)
+
+func main() {
+	manual, err := os.Open("MANUAL.md")
+	if err != nil {
+		log.Fatal(err)
+	}
+	out, err := os.Create("../webhookdb-api/webhookdb-website/src/docs/manual.md")
+	if err != nil {
+		log.Fatal(err)
+	}
+	out.WriteString("---\ntitle: Manual\npath: /docs/manual\norder: 3\n---\nAll commands for the WebhookDB CLI.\n\n```toc\n```\n\n")
+	scanner := bufio.NewScanner(manual)
+	var prevLine string
+	for scanner.Scan() {
+		origLine := scanner.Text()
+		line := origLine
+		if strings.HasPrefix(line, "#") {
+			// Indent all headings once
+			line = "#" + line
+			// If line has an uppercase, it's not a command, so title case it.
+			// We must lower it first, since Title doesn't work right otherwise ('NAME' stays 'NAME').
+			if strings.ToUpper(line) == line {
+				line = strings.Title(strings.ToLower(line))
+			}
+			// Split out the ### prefix from the title
+			headingLevelSep := strings.Index(line, " ")
+			title := line[headingLevelSep+1:]
+			// Create anchors with IDs so they can go into the TOC
+			slug := ToKebabCase(title)
+			anchor := fmt.Sprintf("<a id=\"%s\"></a>", slug)
+			line = fmt.Sprintf("%s\n\n%s [%s](#%s)", anchor, line[:headingLevelSep], title, slug)
+		} else if strings.HasPrefix(line, "\t") {
+			if prevLine == "" {
+				// Open a markdown ``` block with language if indented
+				line = "```arff\n" + strings.TrimSpace(line)
+			} else {
+				// Keep going with the block
+				line = strings.TrimSpace(line)
+			}
+		} else if origLine == "" && strings.HasPrefix(prevLine, "\t") {
+			// End of indented block, finish the ```
+			line = "```"
+		} else if origLine == "```" && prevLine == "" {
+			// Start of a ``` block with no lang, so add it
+			line = "```arff"
+		}
+		out.WriteString(line)
+		out.WriteString("\n")
+		prevLine = origLine
+	}
+	if err := scanner.Err(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+var matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
+var matchAllCap = regexp.MustCompile("([a-z0-9])([A-Z])")
+var matchNonAlphanum = regexp.MustCompile("[^a-zA-Z0-9]+")
+
+func ToKebabCase(str string) string {
+	keb := str
+	keb = matchNonAlphanum.ReplaceAllString(keb, "")
+	keb = matchFirstCap.ReplaceAllString(keb, "${1}_${2}")
+	keb = matchAllCap.ReplaceAllString(keb, "${1}_${2}")
+	keb = strings.ToLower(str)
+	keb = strings.Replace(keb, " ", "-", -1)
+	keb = strings.Replace(keb, "-_", "-", -1)
+	return keb
+}

--- a/cmd/cmd_db.go
+++ b/cmd/cmd_db.go
@@ -118,9 +118,9 @@ var dbCmd = &cli.Command{
 				&cli.BoolFlag{Name: "fdw", Usage: "Write the FDW SQL to stdout"},
 				&cli.BoolFlag{Name: "views", Usage: "Write the SQL to create the materialized views to stdout"},
 				&cli.BoolFlag{Name: "all", Usage: "Write a single SQL statement containing FDW and view creation code. Default if neither --fdw or --views are passed."},
-				&cli.StringFlag{Name: "remote", Value: "webhookdb_remote", Usage: "The remote server name, used in the 'CREATE SERVER <remote>' call"},
+				&cli.StringFlag{Name: "remote", Value: "webhookdb_remote", Usage: "The remote server name, used in the `CREATE SERVER <remote>` call"},
 				&cli.StringFlag{Name: "fetch", Value: "50000", Usage: "fetch_size option used during server creation"},
-				&cli.StringFlag{Name: "into-schema", Value: "webhookdb_remote", Usage: "Name of the schema to import the remote tables into (IMPORT FOREIGN SCHEMA public INTO <into schema>."},
+				&cli.StringFlag{Name: "into-schema", Value: "webhookdb_remote", Usage: "Name of the schema to import the remote tables into (in `IMPORT FOREIGN SCHEMA public INTO <into schema>` call)."},
 				&cli.StringFlag{Name: "views-schema", Value: "webhookdb", Usage: "Create materialized views in this schema. You can use 'public' if you do not want to qualify webhookdb tables."},
 			},
 			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context) error {


### PR DESCRIPTION
We need to add the manual to the website,
but it needs some adjustment.

This adds a Go helper that will read and write MANUAL.md
over to the website directory so it renders well.

Also rebuilds the manual and tweaks the docs.