### PR TITLE
Fix invalid response for state machines

### DIFF
--- a/client/statemachine.go
+++ b/client/statemachine.go
@@ -89,7 +89,12 @@ func (sm StateMachine) RunWithOutput(c context.Context, auth Auth, startingStep 
 			Value:              value,
 		}
 		newStep, err := TransitionStep(c, auth, transitionInput)
-		if err != nil {
+		if eresp, ok := err.(ErrorResponse); ok && eresp.Err.Code == "validation_error" {
+			// Print the message and offer the same prompt again for new input.
+			sm.ask.Feedback(eresp.Err.Message)
+			sm.ask.Feedback("")
+			continue
+		} else if err != nil {
 			return newStep, err
 		}
 		step = newStep


### PR DESCRIPTION
If the state machine transition request errored with a 400,
we would treat it as an unhandled error.

Instead, we should look for "validation_error" responses
and handle them specially by printing the message
and trying again.

Fixes https://github.com/lithictech/webhookdb-api/issues/277