### PR TITLE
Sentry integration, and warn about out-of-order args

### DIFF
--- a/cmd/cmd_db.go
+++ b/cmd/cmd_db.go
@@ -181,7 +181,7 @@ var dbCmd = &cli.Command{
 				&cli.StringFlag{
 					Name:    "new-name",
 					Aliases: s1("n"),
-					Usage:   "The new name of the table",
+					Usage:   "The new name of the table. " + tableNameRules,
 				},
 			},
 			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context) error {

--- a/cmd/cmd_debug.go
+++ b/cmd/cmd_debug.go
@@ -57,6 +57,23 @@ var debugCmd = &cli.Command{
 			}),
 		},
 		{
+			Name:  "printargs",
+			Usage: "Print out positional arguments and flags, to help debug command parsing.",
+			Flags: []cli.Flag{
+				&cli.StringFlag{Name: "mystr"},
+				&cli.BoolFlag{Name: "mybool"},
+			},
+			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context) error {
+				for _, f := range c.FlagNames() {
+					fmt.Fprintf(c.App.Writer, "Flag %s: %v\n", f, c.String(f))
+				}
+				for i, a := range c.Args().Slice() {
+					fmt.Fprintf(c.App.Writer, "Arg %d: %s\n", i, a)
+				}
+				return nil
+			}),
+		},
+		{
 			Name:  "update-auth-display",
 			Usage: "Used to update the WASM terminal on startup.",
 			Action: cliAction(func(c *cli.Context, appContext appcontext.AppContext, ctx context.Context) error {

--- a/cmd/cmd_debug.go
+++ b/cmd/cmd_debug.go
@@ -7,6 +7,7 @@ import (
 	"github.com/lithictech/go-aperitif/convext"
 	"github.com/lithictech/webhookdb-cli/appcontext"
 	"github.com/lithictech/webhookdb-cli/ask"
+	"github.com/lithictech/webhookdb-cli/client"
 	"github.com/lithictech/webhookdb-cli/types"
 	"github.com/urfave/cli/v2"
 	"time"
@@ -86,6 +87,32 @@ var debugCmd = &cli.Command{
 			Usage: "Test out a panic",
 			Action: cliAction(func(c *cli.Context, appContext appcontext.AppContext, ctx context.Context) error {
 				panic("can you see this?")
+			}),
+		},
+		{
+			Name:  "statusz",
+			Usage: "Check the server status.",
+			Action: cliAction(func(c *cli.Context, appContext appcontext.AppContext, ctx context.Context) error {
+				r := client.RestyFromContext(ctx)
+				resp, err := r.R().Get("/statusz")
+				if err != nil {
+					return err
+				}
+				fmt.Fprintln(c.App.Writer, string(resp.Body()))
+				return nil
+			}),
+		},
+		{
+			Name:  "fourohfour",
+			Usage: "Make a 404 request to see how the CLI responds.",
+			Action: cliAction(func(c *cli.Context, appContext appcontext.AppContext, ctx context.Context) error {
+				r := client.RestyFromContext(ctx)
+				resp, err := r.R().Get("/this-does-not-exist")
+				if err != nil {
+					return err
+				}
+				fmt.Fprintln(c.App.Writer, string(resp.Body()))
+				return nil
 			}),
 		},
 	},

--- a/cmd/cmd_flags.go
+++ b/cmd/cmd_flags.go
@@ -54,7 +54,7 @@ func getIntegrationFlagOrArg(c *cli.Context) string {
 func usernameFlag() *cli.StringFlag {
 	return &cli.StringFlag{
 		Name:    "username",
-		Aliases: s1("u"),
+		Aliases: []string{"u", "email"},
 		Usage:   "Takes an email.",
 	}
 }

--- a/cmd/cmd_helpers.go
+++ b/cmd/cmd_helpers.go
@@ -105,3 +105,7 @@ func printlnif(c *cli.Context, msg string, linebr bool) {
 		fmt.Fprintln(c.App.Writer)
 	}
 }
+
+const tableNameRules = "Valid table names must adhere to the following rules: " +
+	"must begin with an ASCII letter, contain only ASCII letters, numbers, underscores, dashes, and spaces, " +
+	"can begin and end with double quotes, and must otherwise be a valid Postgres identifier."

--- a/cmd/cmd_helpers.go
+++ b/cmd/cmd_helpers.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"github.com/go-resty/resty/v2"
 	"github.com/lithictech/go-aperitif/convext"
 	"github.com/lithictech/go-aperitif/logctx"
 	"github.com/lithictech/webhookdb-cli/appcontext"
@@ -26,6 +27,12 @@ func newAppCtx(c *cli.Context) appcontext.AppContext {
 	if err != nil {
 		panic(err)
 	}
+	appCtx.Resty.OnAfterResponse(func(rc *resty.Client, r *resty.Response) error {
+		if r.StatusCode() == 404 || r.StatusCode() >= 500 {
+			return onServerError(c, appCtx, r)
+		}
+		return nil
+	})
 	return appCtx
 }
 

--- a/cmd/cmd_integrations.go
+++ b/cmd/cmd_integrations.go
@@ -21,8 +21,9 @@ var integrationsCmd = &cli.Command{
 				&cli.BoolFlag{
 					Name:    "confirm",
 					Aliases: s1("c"),
-					Usage: "Confirm that you want to use the same service for more than one integration on an org. " +
-						"Will be prompted if not provided.",
+					Usage: "If there is already an integration for this service, " +
+						"you will be prompted to confirm you want to create a new integration. " +
+						"Pass --confirm to automatically accept this prompt and always create a new integration.",
 				},
 			},
 			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context) error {

--- a/cmd/cmd_wasm.go
+++ b/cmd/cmd_wasm.go
@@ -7,6 +7,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/go-resty/resty/v2"
+	"github.com/lithictech/webhookdb-cli/appcontext"
 	"github.com/lithictech/webhookdb-cli/ask"
 	"github.com/lithictech/webhookdb-cli/prefs"
 	"github.com/urfave/cli/v2"
@@ -112,3 +114,8 @@ func wasmUpdateAuthDisplay(p prefs.Prefs) {
 }
 
 var IsTty = false
+
+func onServerError(*cli.Context, appcontext.AppContext, *resty.Response) error {
+	// Eventually we may want to use Sentry from the browser.
+	return nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -27,24 +27,28 @@ type Config struct {
 	// It defaults to API_HOST but you can set it to something else
 	// so multiple api hosts can use the same prefs,
 	// like if they are backed by the same DB.
-	PrefsNamespace string
-	Privacy        bool
-	SentryDsn      string
-	WebsiteHost    string
+	PrefsNamespace   string
+	Privacy          bool
+	SentryDsn        string
+	SkipArgFlagCheck bool
+	WebsiteHost      string
 }
+
+const SkipArgFlagCheckEnv = "WEBHOOKDB_SKIP_ARG_FLAG_CHECK"
 
 func LoadConfig(filenames ...string) Config {
 	_ = godotenv.Overload(filenames...)
 	cfg := Config{
-		ApiHost:        MustEnvStr("WEBHOOKDB_API_HOST"),
-		Debug:          os.Getenv("WEBHOOKDB_DEBUG") != "",
-		LogFile:        os.Getenv("WEBHOOKDB_LOG_FILE"),
-		LogFormat:      os.Getenv("WEBHOOKDB_LOG_FORMAT"),
-		LogLevel:       MustEnvStr("WEBHOOKDB_LOG_LEVEL"),
-		Privacy:        os.Getenv("WEBHOOKDB_PRIVACY") != "",
-		PrefsNamespace: os.Getenv("WEBHOOKDB_PREFS_NAMESPACE"),
-		SentryDsn:      os.Getenv("WEBHOOKDB_SENTRY_DSN"),
-		WebsiteHost:    MustEnvStr("WEBHOOKDB_WEBSITE_HOST"),
+		ApiHost:          MustEnvStr("WEBHOOKDB_API_HOST"),
+		Debug:            os.Getenv("WEBHOOKDB_DEBUG") != "",
+		LogFile:          os.Getenv("WEBHOOKDB_LOG_FILE"),
+		LogFormat:        os.Getenv("WEBHOOKDB_LOG_FORMAT"),
+		LogLevel:         MustEnvStr("WEBHOOKDB_LOG_LEVEL"),
+		Privacy:          os.Getenv("WEBHOOKDB_PRIVACY") != "",
+		PrefsNamespace:   os.Getenv("WEBHOOKDB_PREFS_NAMESPACE"),
+		SentryDsn:        os.Getenv("WEBHOOKDB_SENTRY_DSN"),
+		SkipArgFlagCheck: convext.MustParseBool(lookupEnv(SkipArgFlagCheckEnv, "0")),
+		WebsiteHost:      MustEnvStr("WEBHOOKDB_WEBSITE_HOST"),
 	}
 	if cfg.PrefsNamespace == "" {
 		cfg.PrefsNamespace = cfg.ApiHost
@@ -69,10 +73,18 @@ func MustSetEnv(k string, v interface{}) {
 	}
 }
 
+func lookupEnv(k, d string) string {
+	e := os.Getenv(k)
+	if e == "" {
+		return d
+	}
+	return e
+}
+
 const SentryDsnProd = "https://3e125fd192c34979b2f1a4a5ceb9abd6@o292308.ingest.sentry.io/6224206"
 
 func init() {
-	MustSetEnv("WEBHOOKDB_LOG_LEVEL", "error")
 	MustSetEnv("WEBHOOKDB_API_HOST", "https://api.production.webhookdb.com")
+	MustSetEnv("WEBHOOKDB_LOG_LEVEL", "error")
 	MustSetEnv("WEBHOOKDB_WEBSITE_HOST", "https://webhookdb.com")
 }


### PR DESCRIPTION
Sentry should report errors from the client

Fixes https://github.com/lithictech/webhookdb-api/issues/289

If we get a 404, the server doesn't error,
but the CLI certainly should.

This adds a Resty middleware that will call a handler for 404s and 500s
which will configure and call Sentry.
See https://sentry.io/organizations/lithic-technology/issues/3189363997
for an example.

---

Warn about out-of-order arguments

See https://github.com/urfave/cli/blob/master/docs/migrate-v1-to-v2.md#flags-before-args
for some context.

Avoids annoying situations where a flag is silently ignored/missed.

Fixes https://github.com/lithictech/webhookdb-api/issues/293

---

Polish some CLI help text