### PR TITLE
Add another user agent hint, and fix auth error

### DIFF
--- a/appcontext/appcontext.go
+++ b/appcontext/appcontext.go
@@ -94,6 +94,10 @@ func newResty(cfg config.Config) *resty.Client {
 		SetHeader("User-Agent", userAgent).
 		SetHeader("Whdb-User-Agent", userAgent).
 		SetHeader("Whdb-Short-Session", shortSession)
+	platformUA := platformUserAgent()
+	if platformUA != "" {
+		r = r.SetHeader("Whdb-Platform-User-Agent", platformUA)
+	}
 	r.Debug = cfg.Debug
 	return r
 }

--- a/appcontext/appcontext_unix.go
+++ b/appcontext/appcontext_unix.go
@@ -4,3 +4,7 @@
 package appcontext
 
 const shortSession = ""
+
+func platformUserAgent() string {
+	return ""
+}

--- a/appcontext/appcontext_wasm.go
+++ b/appcontext/appcontext_wasm.go
@@ -3,4 +3,18 @@
 
 package appcontext
 
+import "syscall/js"
+
 const shortSession = "1"
+
+func platformUserAgent() string {
+	var nav = js.Global().Get("navigator")
+	if !nav.Truthy() {
+		return ""
+	}
+	var ua = nav.Get("userAgent")
+	if !ua.Truthy() {
+		return ""
+	}
+	return ua.String()
+}

--- a/cmd/cmd_auth.go
+++ b/cmd/cmd_auth.go
@@ -55,7 +55,13 @@ var authCmd = &cli.Command{
 					return err
 				}
 
-				// org information is coming in as a map[string]interface{}
+				// If the state machine finished running, it was probably successful, but maybe not.
+				// If somehow we didn't get real current_customer info, assume it failed, and exit.
+				if result.Extras["current_customer"] == nil || result.Extras["current_customer"]["email"] == nil {
+					return nil
+				}
+
+				// Org information is coming in as a map[string]interface{}
 				defaultOrg := types.Organization{}
 				if err := mapstructure.Decode(result.Extras["current_customer"]["default_organization"], &defaultOrg); err != nil {
 					return err


### PR DESCRIPTION
Avoid erroring if auth state machine is unsuccessful

We assumed that a completed auth state machine
was a successful auth, but that not need be the case.
Return early if we don't get current_customer information.

Fixes https://github.com/lithictech/webhookdb-api/issues/308

---

Add a platform user agent header

For https://github.com/lithictech/webhookdb-api/issues/309