### PR TITLE
Fix duplication in some step output

### DIFF
--- a/ask/ask.go
+++ b/ask/ask.go
@@ -5,13 +5,13 @@ import "errors"
 // ErrBreak represents a 'break' in environments that do not have
 // a real break, like our WASM intepreter.
 // Basically what happens in all cases would be:
-// - The Ask implementation panics with ErrBreak
-// - The handler for this invocation recovers from panics,
-//   and checks if recover() == ErrBreak.
-// - If it is, we should indicate to the caller (the web terminal)
-//   that the client used a break.
-// - The client should interpret this how it needs,
-//   which is going to emulate a normal terminal.
+//   - The Ask implementation panics with ErrBreak
+//   - The handler for this invocation recovers from panics,
+//     and checks if recover() == ErrBreak.
+//   - If it is, we should indicate to the caller (the web terminal)
+//     that the client used a break.
+//   - The client should interpret this how it needs,
+//     which is going to emulate a normal terminal.
 var ErrBreak = errors.New("psuedo-break error")
 var BreakSentinel = "__whdb_break"
 

--- a/client/common.go
+++ b/client/common.go
@@ -28,10 +28,12 @@ const AuthTokenHeader = "Whdb-Auth-Token"
 
 type ErrorResponse struct {
 	Err struct {
-		Message          string `json:"message"`
-		Code             string `json:"code"`
-		Status           int    `json:"status"`
-		StateMachineStep *Step  `json:"state_machine_step"`
+		Message          string              `json:"message"`
+		Code             string              `json:"code"`
+		Status           int                 `json:"status"`
+		Errors           []string            `json:"errors"`
+		FieldErrors      map[string][]string `json:"field_errors"`
+		StateMachineStep *Step               `json:"state_machine_step"`
 	} `json:"error"`
 }
 
@@ -90,7 +92,7 @@ func makeRequestWithResponse(c context.Context, method string, auth Auth, body, 
 	}
 	if err := CoerceError(resp); err != nil {
 		if eresp, ok := err.(ErrorResponse); ok && eresp.Err.StateMachineStep != nil {
-			errStep, err := NewStateMachine().RunWithOutput(c, auth, *eresp.Err.StateMachineStep)
+			errStep, err := NewStateMachine().Run(c, auth, *eresp.Err.StateMachineStep)
 			if err != nil {
 				return errStep.RawResponse, err
 			}

--- a/cmd/cmd_auth.go
+++ b/cmd/cmd_auth.go
@@ -55,7 +55,7 @@ var authCmd = &cli.Command{
 				if authOut.Complete {
 					result = authOut
 				} else {
-					result, err = client.NewStateMachine().RunWithOutput(ctx, ac.Auth, authOut)
+					result, err = client.NewStateMachine().Run(ctx, ac.Auth, authOut)
 					if err != nil {
 						return err
 					}

--- a/cmd/cmd_helpers.go
+++ b/cmd/cmd_helpers.go
@@ -213,7 +213,7 @@ const tableNameRules = "Valid table names must adhere to the following rules: " 
 // urfave/cli/flag.go#unquoteUsage looks for backticks and uses the value within the backticks
 // as the usage value, like `Usage: "hello `there`" would print `--flag there` instead of `--flag value`.
 // This is bad when you want to use a command like `webhookdb foo` in the usage string, you'd get `--flag webhookdb foo`.
-// If there is a backtick in s, then prepend '``' to short-circuit the unquote behavior.
+// If there is a backtick in s, then prepend '\`\`' to short-circuit the unquote behavior.
 //
 // To avoid this workaround and get the urfave behavior, don't use this method.
 func usage(s string) string {


### PR DESCRIPTION
Fixes https://github.com/lithictech/webhookdb-api/issues/616

I'm not sure why, but when a state machine was run, if the step was complete,
we'd always print output and finish the step.

This meant that if you pass in a completed step,
you could get the output printed again,
because the output *also* prints when the step is returned from the API.

Instead, if we try to transition a completed step, we should no-op, rather than print.

Additionally, one bug with the CLI is that invalid fields (for example the `role` in `wh org invite --role=foo`) would 400, and the state machine would fail the transition and re-prompt for the org member email (because POSTing the email failed the transition, but not because the email was invalid).

Instead, with https://github.com/lithictech/webhookdb-api/pull/652 we have a better validation error shape. This allows us to check that the parameter being POSTed for the transition is one of the parameters that failed validation. If it is, then we're safe to re-prompt. If it's NOT a parameter that failed validation,
we know the caller can't fix the problem from the state machine, it requires a new CLI call, so we can exit.