### PR TITLE
Fix bug where step messages don't print

### DIFF
--- a/client/statemachine.go
+++ b/client/statemachine.go
@@ -99,7 +99,13 @@ func StateMachineResponseRunner(ctx context.Context, auth Auth) func(Step, error
 		if err != nil {
 			return step, err
 		}
-		newStep, newErr := NewStateMachine().Run(ctx, auth, step)
+		sm := NewStateMachine()
+		if step.Complete {
+			// Run assumes that the step passed in isn't complete.
+			sm.ask.Feedback(step.Output)
+			return step, nil
+		}
+		newStep, newErr := sm.Run(ctx, auth, step)
 		if newErr != nil {
 			return step, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lithictech/webhookdb-cli
 
-go 1.17
+go 1.20
 
 require (
 	github.com/MichaelMure/go-term-markdown v0.1.4


### PR DESCRIPTION
Fix bug where step messages don't print

If the API responds with a completed step,
we weren't printing the message.

---

Upgrade Go, 1.17 is too old at this point
