### PR TITLE
Always submits org identifier in `webhook create` requests

### DIFF
--- a/cmd/cmd_webhook.go
+++ b/cmd/cmd_webhook.go
@@ -31,11 +31,10 @@ var webhooksCmd = &cli.Command{
 				input := client.WebhookCreateInput{
 					Url:           c.String("url"),
 					WebhookSecret: c.String("secret"),
+					OrgIdentifier: getOrgFlag(c, ac.Prefs),
 				}
 				if c.String("integration") != "" {
 					input.IntegrationIdentifier = c.String("integration")
-				} else {
-					input.OrgIdentifier = getOrgFlag(c, ac.Prefs)
 				}
 				out, err := client.WebhookCreate(ctx, ac.Auth, input)
 				if err != nil {


### PR DESCRIPTION
The problem is that without an org identifier to use as a route param, `webhook create` requests would always get sent to an invalid url. So even when we are creating webhook subscriptions for single integrations we need to provide the org identifier.