### PR TITLE
New commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,12 @@ ARGS := WEBHOOKDB_API_HOST=http://localhost:18001
 BUILDFLAGS = "-X github.com/lithictech/webhookdb-cli/config.BuildTime=`date -u +"%Y-%m-%dT%H:%M:%SZ"` -X github.com/lithictech/webhookdb-cli/config.BuildSha=`git rev-list -1 HEAD`"
 WEBSITE = ../webhookdb-api/webhookdb-website
 
+ifdef GOROOT
+GO := $(GOROOT)/bin/go
+else
+GO := go
+endif
+
 guardcmd-%:
 	@hash $(*) > /dev/null 2>&1 || \
 		(echo "ERROR: '$(*)' must be installed and available on your PATH."; exit 1)
@@ -17,10 +23,10 @@ lint: guardcmd-gofmt
 	@test -z $$(gofmt -d -l . | tee /dev/stderr) && echo "gofmt ok"
 
 vet:
-	@go vet && echo "go vet ok"
+	@$(GO) vet && echo "go vet ok"
 
 test:
-	go test .
+	$(GO) test .
 	@WEBHOOKDB_LOG_LEVEL=fatal ginkgo -r --trace --race --progress --skipMeasurements
 
 test-watch:
@@ -35,13 +41,13 @@ bench:
 check: vet lint
 
 build:
-	@go build -ldflags $(BUILDFLAGS) -o webhookdb
+	@$(GO) build -ldflags $(BUILDFLAGS) -o webhookdb
 
 build-arm64:
-	@GOOS=darwin go build -ldflags $(BUILDFLAGS) -o webhookdb
+	@GOOS=darwin $(GO) build -ldflags $(BUILDFLAGS) -o webhookdb
 
 build-wasm:
-	@GOOS=js GOARCH=wasm go build -ldflags $(BUILDFLAGS) -o webhookdb.wasm
+	@GOOS=js GOARCH=wasm $(GO) build -ldflags $(BUILDFLAGS) -o webhookdb.wasm
 
 _goreleaser-clean:
 	rm -rf ./dist
@@ -52,13 +58,13 @@ goreleaser-local: _goreleaser-clean
 	GITHUB_TOKEN=notreal goreleaser
 
 wasm-server:
-	go run bin/serve-wasm/main.go
+	$(GO) run bin/serve-wasm/main.go
 
 build-all: build-arm64 build build-wasm
 
 copy-to-web: ## Copy the WASM and MANUAL.md to the website directory.
 	@cp webhookdb.wasm $(WEBSITE)/static/webterm
-	@go run bin/copy-manual/main.go
+	@$(GO) run bin/copy-manual/main.go
 
 docs-write: build ## Write a new copy of MANUAL.md.
 	@DOCBUILD=true $(BIN) docs build | grep -v '^%!(' > MANUAL.md
@@ -66,11 +72,11 @@ docs-write: build ## Write a new copy of MANUAL.md.
 build-and-copy-to-web: docs-write build-wasm copy-to-web
 
 update-lithic-deps:
-	go get github.com/rgalanakis/golangal@latest
-	go get github.com/lithictech/go-aperitif@latest
+	$(GO) get github.com/rgalanakis/golangal@latest
+	$(GO) get github.com/lithictech/go-aperitif@latest
 
 help:
-	@go run ./main.go help
+	@$(GO) run ./main.go help
 
 itest-auth-login: build
 	$(ARGS) $(BIN) auth login --username=alpha@lithic.tech

--- a/client/integrations.go
+++ b/client/integrations.go
@@ -53,6 +53,15 @@ func IntegrationsList(c context.Context, auth Auth, input IntegrationsListInput)
 	return
 }
 
+type IntegrationsSetupInput struct {
+	IntegrationIdentifier string              `json:"-"`
+	OrgIdentifier         types.OrgIdentifier `json:"-"`
+}
+
+func IntegrationsSetup(c context.Context, auth Auth, input IntegrationsSetupInput) (Step, error) {
+	return makeStepRequestWithResponse(c, auth, nil, "/v1/organizations/%v/service_integrations/%v/setup", input.OrgIdentifier, input.IntegrationIdentifier)
+}
+
 type IntegrationsResetInput struct {
 	IntegrationIdentifier string              `json:"-"`
 	OrgIdentifier         types.OrgIdentifier `json:"-"`

--- a/cmd/cmd_fixtures.go
+++ b/cmd/cmd_fixtures.go
@@ -8,7 +8,8 @@ import (
 )
 
 var fixturesCmd = &cli.Command{
-	Name: "fixtures",
+	Name:    "fixtures",
+	Aliases: []string{"fixture"},
 	Usage: "Output the SQL DDL (CREATE TABLE command) to create a DB table that matches what is in WebhookDB. " +
 		"This can be used to generate .sql files that can be run as part of test database fixturing.",
 	Flags: []cli.Flag{serviceFlag()},

--- a/cmd/cmd_integrations.go
+++ b/cmd/cmd_integrations.go
@@ -111,6 +111,21 @@ var integrationsCmd = &cli.Command{
 			}),
 		},
 		{
+			Name:  "setup",
+			Usage: "Ensure all the necessary fields are set to receive webhooks.",
+			Flags: []cli.Flag{
+				orgFlag(),
+				integrationFlag(),
+			},
+			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context) error {
+				input := client.IntegrationsSetupInput{
+					IntegrationIdentifier: getIntegrationFlagOrArg(c),
+					OrgIdentifier:         getOrgFlag(c, ac.Prefs),
+				}
+				return stateMachineResponseRunner(ctx, ac.Auth)(client.IntegrationsSetup(ctx, ac.Auth, input))
+			}),
+		},
+		{
 			Name:  "reset",
 			Usage: "Reset the webhook secret for this integration.",
 			Flags: []cli.Flag{

--- a/cmd/cmd_notification.go
+++ b/cmd/cmd_notification.go
@@ -9,7 +9,7 @@ import (
 
 var webhooksCmd = &cli.Command{
 	Name:    "notification",
-	Aliases: []string{"notification", "notifications", "webhook", "webhooks"},
+	Aliases: []string{"notifications", "webhook", "webhooks"},
 	Usage:   "Manage endpoints that will be notified when WebhookDB data is updated.",
 	Subcommands: []*cli.Command{
 		{

--- a/cmd/cmd_notification.go
+++ b/cmd/cmd_notification.go
@@ -8,13 +8,13 @@ import (
 )
 
 var webhooksCmd = &cli.Command{
-	Name:    "webhook",
-	Aliases: []string{"webhooks"},
-	Usage:   "Manage webhooks that will be notified when WebhookDB data is updated.",
+	Name:    "notification",
+	Aliases: []string{"notification", "notifications", "webhook", "webhooks"},
+	Usage:   "Manage endpoints that will be notified when WebhookDB data is updated.",
 	Subcommands: []*cli.Command{
 		{
 			Name:  "create",
-			Usage: "Create a new webhook that WebhookDB will call on every data update.",
+			Usage: "Create a new notification that WebhookDB will call on every data update.",
 			Flags: []cli.Flag{
 				orgFlag(),
 				integrationFlag(),
@@ -24,7 +24,7 @@ var webhooksCmd = &cli.Command{
 				},
 				&cli.StringFlag{
 					Name:  "secret",
-					Usage: "Random secure secret to use to sign webhooks coming from WebhookDB.",
+					Usage: "Random secure secret to use to sign notifications coming from WebhookDB.",
 				},
 			},
 			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context) error {
@@ -44,7 +44,7 @@ var webhooksCmd = &cli.Command{
 		},
 		{
 			Name:  "list",
-			Usage: "List all created webhooks.",
+			Usage: "List all created notifications.",
 			Flags: []cli.Flag{
 				orgFlag(),
 				formatFlag(),
@@ -63,12 +63,12 @@ var webhooksCmd = &cli.Command{
 		},
 		{
 			Name:  "test",
-			Usage: "Send a test event to webhook subscription with the given ID.",
-			Flags: []cli.Flag{webhookFlag()},
+			Usage: "Send a test event to the notification subscription with the given ID.",
+			Flags: []cli.Flag{notificationFlag()},
 			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context) error {
 				out, err := client.WebhookTest(ctx, ac.Auth, client.WebhookOpaqueIdInput{
 					OrgIdentifier: getOrgFlag(c, ac.Prefs),
-					OpaqueId:      getWebhookFlagOrArg(c),
+					OpaqueId:      getNotificationArgOrFlag(c),
 				})
 				if err != nil {
 					return err
@@ -79,12 +79,12 @@ var webhooksCmd = &cli.Command{
 		},
 		{
 			Name:  "delete",
-			Usage: "Delete this webhook subscription, so no future events will be sent.",
-			Flags: []cli.Flag{webhookFlag()},
+			Usage: "Delete this notification subscription, so no future events will be sent.",
+			Flags: []cli.Flag{notificationFlag()},
 			Action: cliAction(func(c *cli.Context, ac appcontext.AppContext, ctx context.Context) error {
 				out, err := client.WebhookDelete(ctx, ac.Auth, client.WebhookOpaqueIdInput{
 					OrgIdentifier: getOrgFlag(c, ac.Prefs),
-					OpaqueId:      getWebhookFlagOrArg(c),
+					OpaqueId:      getNotificationArgOrFlag(c),
 				})
 				if err != nil {
 					return err
@@ -96,14 +96,14 @@ var webhooksCmd = &cli.Command{
 	},
 }
 
-func webhookFlag() *cli.StringFlag {
+func notificationFlag() *cli.StringFlag {
 	return &cli.StringFlag{
-		Name:    "webhook",
-		Aliases: s1("w"),
-		Usage:   usage("Webhook opaque id. Run `webhookdb webhook list` to see a list of all your webhooks."),
+		Name:    "notification",
+		Aliases: s1("n"),
+		Usage:   usage("Notification opaque id. Run `webhookdb notification list` to see a list of all your notification subscriptions."),
 	}
 }
 
-func getWebhookFlagOrArg(c *cli.Context) string {
-	return requireFlagOrArg(c, "webhook", "Use `webhookdb webhook list` to see available webhooks.")
+func getNotificationArgOrFlag(c *cli.Context) string {
+	return requireFlagOrArg(c, "notification", "Use `webhookdb notification list` to see available notifications.")
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lithictech/webhookdb-cli
 
-go 1.20
+go 1.17
 
 require (
 	github.com/MichaelMure/go-term-markdown v0.1.4


### PR DESCRIPTION
Makefile: Go binary has to be configurable

Since we have to build with an old version of Go,
we need to make it easier to use that particular version.

---

Add the new 'integration setup' command

---

Add aliases for fixtures and notifications

---

Rename 'webhooks' to 'notifications'

Keep up with new, less-confusing terminology.
